### PR TITLE
Add top-level control on Cloud definition: key=enabled

### DIFF
--- a/scheduler/config/config.go
+++ b/scheduler/config/config.go
@@ -18,6 +18,9 @@ type Cloud struct {
 	// by the scheduler later, depending on priorities configured.
 	// It's possible to add it to the config though, if needed.
 	Weight int `json:"weight"`
+	// Enabled defines if the cloud can be selected when loading the config. It's a top-level control. If it's set to false, then the cloud will not be loaded in the configuration. It takes precedence over scheduling, thus over taints and tolerations.
+	// True by default.
+	Enabled bool `json:"enabled"`
 }
 
 func loadClouds() map[string]Cloud {
@@ -38,7 +41,7 @@ func loadClouds() map[string]Cloud {
 		})
 
 	if err != nil {
-		log.Err.Println(err)
+		log.Err.Fatal(err)
 	}
 	log.Debug.Printf("Found %d configuration files for clouds\n",  len(cloudFileList))
 
@@ -50,14 +53,16 @@ func loadClouds() map[string]Cloud {
 			log.Err.Println("Error in loadClouds()")
 			log.Err.Fatal(err)
 		}
-		cloud := Cloud{}
+		cloud := Cloud{Enabled: true}
 		err = yaml.Unmarshal(content, &cloud)
 		if err != nil {
 			log.Err.Println("Cannot read configuration of clouds.yml")
 			log.Err.Fatalf("Cannot unmarshal data: %v", err)
 		} else {
-			log.Debug.Printf("Found cloud %s\n", cloud.Name)
-			clouds[cloud.Name] = cloud
+			log.Debug.Printf("Found cloud %s (enabled=%v)\n", cloud.Name, cloud.Enabled)
+			if cloud.Enabled {
+				clouds[cloud.Name] = cloud
+			}
 		}
 	}
 

--- a/scheduler/modules/labels.go
+++ b/scheduler/modules/labels.go
@@ -11,6 +11,7 @@ func LabelPredicates(clouds map[string]config.Cloud, labels map[string]string) m
 
 out:
 	for k, v := range clouds {
+		// Check if all labels match
 		for lk, lv := range labels {
 			if v.Labels[lk] != lv {
 				continue out


### PR DESCRIPTION
This commit if applied will add the ability to enable or disable entirely a
cloud.

If a cloud is `enabled=false`  its configuration is not loaded by the scheduler.

This is a way for OPS to entirely disable a cloud.

It takes precedence over (future) taints and tolerations.