### PR TITLE
Add redis database to the scheduler

### DIFF
--- a/scheduler/db/redis.go
+++ b/scheduler/db/redis.go
@@ -1,0 +1,22 @@
+package db
+
+
+import (
+	"github.com/gomodule/redigo/redis"
+	"github.com/redhat-gpe/scheduler/log"
+)
+
+var redisURL string
+
+func InitContext(url string) {
+	redisURL = url
+}
+
+func Dial() redis.Conn {
+	conn, err := redis.DialURL(redisURL)
+	if err != nil {
+		log.Err.Println(err)
+	}
+
+	return conn
+}

--- a/scheduler/git/git.go
+++ b/scheduler/git/git.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"io/ioutil"
 	"os"
+	"time"
+	"errors"
 )
 
 var configRepo *git.Repository
@@ -100,10 +102,16 @@ func CloneRepository(url string, sshPrivateKey string) {
 	configRepoDir = dir
 }
 
+var lastUpdated time.Time
+
 // This function refreshes the git Worktree containing the configuration of the scheduler.
 // It's basically running the equivalent of 'git pull'.
 func RefreshRepository() error {
-	// Use WaitGroup to avoid spamming github with 'git pull'
+	// Do not spam git pull. Allow only one pull every 10 seconds for this process.
+	if time.Now().Sub(lastUpdated) < 10 * time.Second {
+		log.Debug.Println("Git repo updated recently. Ignoring.")
+		return errors.New("updated too recently")
+	}
 	wt, err:= configRepo.Worktree()
 
 	if err != nil {
@@ -122,6 +130,8 @@ func RefreshRepository() error {
 			log.Err.Println(err)
 		}
 	}
+
+	lastUpdated = time.Now()
 
 	return err
 }

--- a/scheduler/go.mod
+++ b/scheduler/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/go-git/go-git/v5 v5.1.0
+	github.com/gomodule/redigo v1.8.2
 	github.com/julienschmidt/httprouter v1.3.0
 	golang.org/x/crypto v0.0.0-20200604202706-70a84ac30bf9
 	golang.org/x/net v0.0.0-20200602114024-627f9648deb9 // indirect

--- a/scheduler/go.sum
+++ b/scheduler/go.sum
@@ -7,6 +7,7 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkY
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
@@ -23,6 +24,9 @@ github.com/go-git/go-git-fixtures/v4 v4.0.1 h1:q+IFMfLx200Q3scvt2hN79JsEzy4AmBTp
 github.com/go-git/go-git-fixtures/v4 v4.0.1/go.mod h1:m+ICp2rF3jDhFgEZ/8yziagdT1C+ZpZcrJjappBCDSw=
 github.com/go-git/go-git/v5 v5.1.0 h1:HxJn9g/E7eYvKW3Fm7Jt4ee8LXfPOm/H1cdDu8vEssk=
 github.com/go-git/go-git/v5 v5.1.0/go.mod h1:ZKfuPUoY1ZqIG4QG9BDBh3G4gLM5zvPuSJAozQrZuyM=
+github.com/gomodule/redigo v1.8.2 h1:H5XSIre1MB5NbPYFp+i1NBbb5qN1W8Y8YAQoAYbkm8k=
+github.com/gomodule/redigo v1.8.2/go.mod h1:P9dn9mFrCBvWhGE1wpxx6fgq7BAeLBk+UUUzlpkBYO0=
+github.com/gomodule/redigo/redis v0.0.0-do-not-use h1:J7XIp6Kau0WoyT4JtXHT3Ei0gA1KkSc6bc87j9v9WIo=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/imdario/mergo v0.3.9 h1:UauaLniWCFHWd+Jp9oCEkTBj8VO/9DKg3PV3VCNMDIg=
 github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
@@ -45,6 +49,7 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWb
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/pelletier/go-buffruneio v0.2.0/go.mod h1:JkE26KsDizTr40EUHkXVtNPvgGtbSNq5BcowyYOWdKo=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
@@ -55,6 +60,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
+github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/xanzy/ssh-agent v0.2.1 h1:TCbipTQL2JiiCprBWx9frJ2eJlCYT00NmctrHxVAr70=
 github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0Bx9h2kr4=
 golang.org/x/crypto v0.0.0-20190219172222-a4c6cb3142f2/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -7,23 +7,27 @@ import(
 	"github.com/redhat-gpe/scheduler/git"
 	"github.com/redhat-gpe/scheduler/log"
 	"github.com/redhat-gpe/scheduler/watcher"
+	"github.com/redhat-gpe/scheduler/db"
 )
 
 // Flags
 var debugFlag bool
 var repositoryURL string
 var sshPrivateKey string
+var redisURL string
 
 func parseFlags() {
 	flag.BoolVar(&debugFlag, "debug", false, "Debug mode")
 	flag.StringVar(&repositoryURL, "git-url", "git@github.com:redhat-gpe/scheduler-config.git", "The URL of the git repository where the scheduler will find its configuration. SSH is assumed, unless the URL starts with 'http'.")
 	flag.StringVar(&sshPrivateKey, "ssh-private-key", "", "The SSH private key used to authenticate to the git repository. Used only when 'git-url' is an SSH URL.")
+	flag.StringVar(&redisURL, "redis-url", "redis://localhost:6379", "The URL to access redis. The format is described by the IANA specification for the scheme, see https://www.iana.org/assignments/uri-schemes/prov/redis")
 	flag.Parse()
 }
 
 func main() {
 	parseFlags()
 	log.InitLoggers(debugFlag)
+	db.InitContext(redisURL)
 	git.CloneRepository(repositoryURL, sshPrivateKey)
 	go watcher.ConsumePullQueue()
 	config.Load()

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -18,15 +18,15 @@ var sshPrivateKey string
 var redisURL string
 
 func parseFlags() {
-	flag.StringVar(&repositoryURL, "git-url", "git@github.com:redhat-gpe/scheduler-config.git", "The URL of the git repository where the scheduler will find its configuration. SSH is assumed, unless the URL starts with 'http'. To set git-url you can also use the environment variable REPOSITORY_URL. If both are set, environment variable prevails.")
-	flag.StringVar(&sshPrivateKey, "ssh-private-key", "", "The SSH private key used to authenticate to the git repository. Used only when 'git-url' is an SSH URL. Environment variable: SSH_PRIVATE_KEY.")
+	flag.StringVar(&repositoryURL, "git-url", "git@github.com:redhat-gpe/scheduler-config.git", "The URL of the git repository where the scheduler will find its configuration. SSH is assumed, unless the URL starts with 'http'. To set git-url you can also use the environment variable GIT_URL. If both are set, environment variable prevails.")
+	flag.StringVar(&sshPrivateKey, "git-ssh-private-key", "", "The SSH private key used to authenticate to the git repository. Used only when 'git-url' is an SSH URL. Environment variable: GIT_SSH_PRIVATE_KEY.")
 	flag.StringVar(&redisURL, "redis-url", "redis://localhost:6379", "The URL to access redis. Environment variable: REDIS_URL. The format is described by the IANA specification for the scheme, see https://www.iana.org/assignments/uri-schemes/prov/redis")
 	flag.BoolVar(&debugFlag, "debug", false, "Debug mode. Environment variable: DEBUG.")
 	flag.Parse()
-	if e := os.Getenv("REPOSITORY_URL"); e != "" {
+	if e := os.Getenv("GIT_URL"); e != "" {
 		repositoryURL = e
 	}
-	if e := os.Getenv("SSH_PRIVATE_KEY"); e != "" {
+	if e := os.Getenv("GIT_SSH_PRIVATE_KEY"); e != "" {
 		sshPrivateKey = e
 	}
 	if e := os.Getenv("REDIS_URL"); e != "" {

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -8,6 +8,7 @@ import(
 	"github.com/redhat-gpe/scheduler/log"
 	"github.com/redhat-gpe/scheduler/watcher"
 	"github.com/redhat-gpe/scheduler/db"
+	"os"
 )
 
 // Flags
@@ -17,11 +18,23 @@ var sshPrivateKey string
 var redisURL string
 
 func parseFlags() {
-	flag.BoolVar(&debugFlag, "debug", false, "Debug mode")
-	flag.StringVar(&repositoryURL, "git-url", "git@github.com:redhat-gpe/scheduler-config.git", "The URL of the git repository where the scheduler will find its configuration. SSH is assumed, unless the URL starts with 'http'.")
-	flag.StringVar(&sshPrivateKey, "ssh-private-key", "", "The SSH private key used to authenticate to the git repository. Used only when 'git-url' is an SSH URL.")
-	flag.StringVar(&redisURL, "redis-url", "redis://localhost:6379", "The URL to access redis. The format is described by the IANA specification for the scheme, see https://www.iana.org/assignments/uri-schemes/prov/redis")
+	flag.StringVar(&repositoryURL, "git-url", "git@github.com:redhat-gpe/scheduler-config.git", "The URL of the git repository where the scheduler will find its configuration. SSH is assumed, unless the URL starts with 'http'. To set git-url you can also use the environment variable REPOSITORY_URL. If both are set, environment variable prevails.")
+	flag.StringVar(&sshPrivateKey, "ssh-private-key", "", "The SSH private key used to authenticate to the git repository. Used only when 'git-url' is an SSH URL. Environment variable: SSH_PRIVATE_KEY.")
+	flag.StringVar(&redisURL, "redis-url", "redis://localhost:6379", "The URL to access redis. Environment variable: REDIS_URL. The format is described by the IANA specification for the scheme, see https://www.iana.org/assignments/uri-schemes/prov/redis")
+	flag.BoolVar(&debugFlag, "debug", false, "Debug mode. Environment variable: DEBUG.")
 	flag.Parse()
+	if e := os.Getenv("REPOSITORY_URL"); e != "" {
+		repositoryURL = e
+	}
+	if e := os.Getenv("SSH_PRIVATE_KEY"); e != "" {
+		sshPrivateKey = e
+	}
+	if e := os.Getenv("REDIS_URL"); e != "" {
+		redisURL = e
+	}
+	if e := os.Getenv("DEBUG"); e != "" && e != "false" {
+		debugFlag = true
+	}
 }
 
 func main() {

--- a/scheduler/watcher/repo.go
+++ b/scheduler/watcher/repo.go
@@ -2,31 +2,40 @@ package watcher
 
 import(
 	"github.com/redhat-gpe/scheduler/git"
+	"github.com/redhat-gpe/scheduler/log"
 	"github.com/redhat-gpe/scheduler/config"
-	"time"
+	"github.com/redhat-gpe/scheduler/db"
+	"github.com/gomodule/redigo/redis"
 )
-
-var (
-	pullQueue = make(chan bool)
-)
-
 
 func RequestPull() {
-	pullQueue <- true
+	conn :=  db.Dial()
+	defer conn.Close()
+
+	conn.Do("PUBLISH", "repoMQ", "pull")
 }
 
-// This function watches the channel 'pullQueue' and executes RefreshRepository when there
-// is a request with a delay of 10 seconds between each call.
+// This function watches the message Queue 'repoMQ' in redis
+// and executes RefreshRepository when there is a request with
+// a delay of 10 seconds between each call.
 // The goal is to avoid spamming github (or whatever the provider).
 func ConsumePullQueue() {
+	conn :=  redis.PubSubConn{Conn:db.Dial()}
+	defer conn.Close()
+
+	conn.Subscribe("repoMQ")
 	for {
-		select {
-		case <- pullQueue:
-			git.RefreshRepository()
-			config.Load()
-			// Empty the queue now that it is refreshed
-			pullQueue = make(chan bool)
-			time.Sleep(10 * time.Second)
+		switch v := conn.Receive().(type) {
+		case redis.Message:
+			log.Debug.Printf("%s: message: %s\n", v.Channel, v.Data)
+			if err := git.RefreshRepository(); err == nil {
+				config.Load()
+			}
+		case redis.Subscription:
+			log.Debug.Printf("%s: %s %d\n", v.Channel, v.Kind, v.Count)
+			continue
+		case error:
+			log.Debug.Println(v)
 		}
 	}
 }


### PR DESCRIPTION
This commit, if applied, adds a redis db to the scheduler.

In order to be able to scale the number of replicas of the scheduler, we need a
way to synchronize the processes. This is can be achieved by using a database
like redis.

Another thing to consider that will require a DB is the future feature:

    taints and tolerations

Taints applied to clouds will be dynamic resources of the scheduler.
The different modules (prometheus, calendar, etc) will possibily taint a cloud,
to reduce its priority, or to set it as unschedulable. An Operator should also
be able to taint a cloud with a single API call.

Again, how we are going to synchronize the taints between the replicas, plus the
ability to recover the state of the taints when the pods are restarted, will be
possible with a DB.