### PR TITLE
Refactor packages and start work on Taints & Tolerations

### DIFF
--- a/scheduler/api/api.go
+++ b/scheduler/api/api.go
@@ -4,7 +4,6 @@ import (
 	"log"
 	"net/http"
 	"github.com/julienschmidt/httprouter"
-	"github.com/redhat-gpe/scheduler/api/v1"
 	"io"
 )
 
@@ -20,11 +19,11 @@ func Serve() {
 	router.GET("/healthz", healthHandler)
 
 	// v1
-	router.GET("/api/v1/clouds", v1.GetClouds)
-	router.GET("/api/v1/clouds/:name", v1.GetCloudByName)
-	router.GET("/api/v1/repo", v1.GetRepository)
-	router.PUT("/api/v1/repo", v1.PullRepository)
-	router.POST("/api/v1/schedule", v1.Schedule)
+	router.GET("/api/v1/clouds", v1GetClouds)
+	router.GET("/api/v1/clouds/:name", v1GetCloudByName)
+	router.GET("/api/v1/repo", v1GetRepository)
+	router.PUT("/api/v1/repo", v1PullRepository)
+	router.POST("/api/v1/schedule", v1Schedule)
 
 	log.Fatal(http.ListenAndServe(":8080", router))
 }

--- a/scheduler/api/v1/toleration.go
+++ b/scheduler/api/v1/toleration.go
@@ -1,0 +1,32 @@
+package v1
+
+import (
+	"strings"
+)
+
+// ToleratesTaint checks if the toleration tolerates the taint.
+// The matching follows the rules below:
+// (1) Empty toleration.effect means to match all taint effects,
+//     otherwise taint effect must equal to toleration.effect.
+// (2) If toleration.operator is 'Exists', it means to match all taint values.
+// (3) Empty toleration.key means to match all taint keys.
+//     If toleration.key is empty, toleration.operator must be 'Exists';
+//     this combination means to match all taint values and all taint keys.
+func (tol Toleration) ToleratesTaint(taint Taint) bool {
+	if len(tol.Effect) > 0 && tol.Effect != taint.Effect {
+		return false
+	}
+
+	if len(tol.Key) > 0 && tol.Key != taint.Key {
+		return false
+	}
+
+	switch strings.ToLower(tol.Operator) {
+	case strings.ToLower(TolerationOpExists):
+		return true
+	case "", strings.ToLower(TolerationOpEqual):
+		return tol.Value == taint.Value
+	default:
+		return false
+	}
+}

--- a/scheduler/api/v1/toleration_test.go
+++ b/scheduler/api/v1/toleration_test.go
@@ -1,0 +1,98 @@
+package v1
+
+import (
+	"testing"
+)
+
+func TestTolerationToleratesTaint(t *testing.T) {
+	testCases := []struct {
+		description string
+		toleration Toleration
+		taint Taint
+		expected bool
+	}{
+		{
+			description: "Taint and Toleration tolerates with Operator Exists",
+			toleration: Toleration{
+				Key: "memory-pressure",
+				Value: "ignored",
+				Effect: TaintEffectNoSchedule,
+				Operator: TolerationOpExists,
+			},
+			taint: Taint{
+				Key: "memory-pressure",
+				Value: "high",
+				Effect: TaintEffectNoSchedule,
+			},
+			expected: true,
+		},
+		{
+			description: "Taint and Toleration tolerates with Operator Equal",
+			toleration: Toleration{
+				Key: "memory-pressure",
+				Value: "high",
+				Effect: TaintEffectNoSchedule,
+				Operator: TolerationOpEqual,
+			},
+			taint: Taint{
+				Key: "memory-pressure",
+				Value: "high",
+				Effect: TaintEffectNoSchedule,
+			},
+			expected: true,
+		},
+		{
+			description: "Taint and Toleration don't tolerates with Operator Equal (Values are different)",
+			toleration: Toleration{
+				Key: "memory-pressure",
+				Value: "high",
+				Effect: TaintEffectNoSchedule,
+				Operator: TolerationOpEqual,
+			},
+			taint: Taint{
+				Key: "memory-pressure",
+				Value: "critical",
+				Effect: TaintEffectNoSchedule,
+			},
+			expected: false,
+		},
+		{
+			description: "Taint and Toleration don't tolerates with Operator Equal (Keys are different)",
+			toleration: Toleration{
+				Key: "memory-pressure",
+				Value: "high",
+				Effect: TaintEffectNoSchedule,
+				Operator: TolerationOpEqual,
+			},
+			taint: Taint{
+				Key: "cpu-pressure",
+				Value: "high",
+				Effect: TaintEffectNoSchedule,
+			},
+			expected: false,
+		},
+		{
+			description: "Taint and Toleration don't tolerates with invalid Operator",
+			toleration: Toleration{
+				Key: "memory-pressure",
+				Value: "high",
+				Effect: TaintEffectNoSchedule,
+				Operator: "invalid",
+			},
+			taint: Taint{
+				Key: "memory-pressure",
+				Value: "high",
+				Effect: TaintEffectNoSchedule,
+			},
+			expected: false,
+		},
+	}
+
+	for _, c := range testCases {
+		r := c.toleration.ToleratesTaint(c.taint)
+
+		if r != c.expected {
+                        t.Errorf("'%s', Expected ToleratesTaint() to be %v but it was %v", c.description, c.expected, r)
+		}
+        }
+}

--- a/scheduler/api/v1/types.go
+++ b/scheduler/api/v1/types.go
@@ -1,5 +1,27 @@
 package v1
 
+// The Cloud is the main object that the scheduler work with.
+type Cloud struct {
+	Name string `json:"name"`
+	Labels map[string]string `json:"labels"`
+	// Weight is usually not provided by config, but automatically filled
+	// by the scheduler later, depending on priorities configured.
+	// It's possible to add it to the config though, if needed.
+	Weight int `json:"weight"`
+	// Enabled defines if the cloud can be selected when loading the config. It's a top-level control. If it's set to false, then the cloud will not be loaded in the configuration. It takes precedence over scheduling, thus over taints and tolerations.
+	// True by default.
+	Enabled bool `json:"enabled"`
+	// Taints are part of the mechanism to reduce the priority (effect=PreferNoSchedule)
+	// or set a cloud as unschedulable (effect=NoSchedule).
+	// The taints prevail over the labels or any other control.
+	// They can be bypass when requesting schedule to the scheduler by
+	// specifying tolerations. In other words, a taint allows a cloud to refuse
+	// deployment to be scheduled unless that deployment has a matching toleration.
+	// Taints are usually dynamic resources managed by the scheduler, but they can also
+	// be statically provided in the configuration.
+	Taints map[string]Taint `json:"taints"`
+}
+
 type Error struct {
 	Code int32 `json:"code"`
 	Message string `json:"message"`
@@ -18,4 +40,54 @@ type GitCommit struct {
 	Hash string `json:"hash"`
 	Author string `json:"author"`
 	Date string `json:"date"`
+}
+
+const(
+	// Do not allow new deployments to be scheduled onto the cloud
+	// unless they tolerate the taint
+	TaintEffectNoSchedule string = "NoSchedule"
+	// Like TaintEffectNoSchedule, but the scheduler tries not to schedule
+	// new deployments onto the cloud, rather than prohibiting new deployment
+	// from scheduling onto the cloud entirely.
+	TaintEffectPreferNoSchedule string = "PreferNoSchedule"
+
+	TolerationOpExists string = "Exists"
+	TolerationOpEqual  string = "Equal"
+)
+
+
+// The cloud this taint is attached to has the "effect" on any deployment that
+// does not tolerate the Taint.
+type Taint struct {
+	// Required. The taint key to be applied to a cloud.
+	Key string `json:"key"`
+	// The taint value corresponding to the taint key.
+	// +optional
+	Value string `json:"value"`
+	// Required. The effect of the taint on deployments that do not tolerate the taint.
+	// Valid effects are NoSchedule, PreferNoSchedule.
+	Effect string `json:"effect"`
+}
+
+// The deployment this Toleration is attached to tolerates any taint that matches
+// the triple <key,value,effect> using the matching operator <operator>.
+type Toleration struct {
+	// Key is the taint key that the toleration applies to. Empty means match all taint keys.
+	// If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+	// +optional
+	Key string `json:"key,omitempty"`
+	// Operator represents a key's relationship to the value.
+	// Valid operators are Exists and Equal. Defaults to Equal.
+	// Exists is equivalent to wildcard for value, so that a cloud can
+	// tolerate all taints of a particular category.
+	// +optional
+	Operator string `json:"operator,omitempty"`
+	// Value is the taint value the toleration matches to.
+	// If the operator is Exists, the value should be empty, otherwise just a regular string.
+	// +optional
+	Value string `json:"value,omitempty"`
+	// Effect indicates the taint effect to match. Empty means match all taint effects.
+	// When specified, allowed values are NoSchedule, PreferNoSchedule.
+	// +optional
+	Effect string `json:"effect,omitempty"`
 }

--- a/scheduler/config/config.go
+++ b/scheduler/config/config.go
@@ -5,25 +5,13 @@ import(
 	"io/ioutil"
 	"github.com/redhat-gpe/scheduler/log"
 	"github.com/redhat-gpe/scheduler/git"
+	"github.com/redhat-gpe/scheduler/api/v1"
 	"path/filepath"
 	"path"
 	"os"
 )
 
-// The Cloud type defines a cloud
-type Cloud struct {
-	Name string `json:"name"`
-	Labels map[string]string `json:"labels"`
-	// Weight is usually not provided by config, but automatically filled
-	// by the scheduler later, depending on priorities configured.
-	// It's possible to add it to the config though, if needed.
-	Weight int `json:"weight"`
-	// Enabled defines if the cloud can be selected when loading the config. It's a top-level control. If it's set to false, then the cloud will not be loaded in the configuration. It takes precedence over scheduling, thus over taints and tolerations.
-	// True by default.
-	Enabled bool `json:"enabled"`
-}
-
-func loadClouds() map[string]Cloud {
+func loadClouds() map[string]v1.Cloud {
 	cloudFileList := []string{}
 	log.Debug.Println(filepath.Join(git.GetRepoDir(), "/clouds"))
 	err := filepath.Walk(filepath.Join(git.GetRepoDir(), "/clouds"),
@@ -45,7 +33,7 @@ func loadClouds() map[string]Cloud {
 	}
 	log.Debug.Printf("Found %d configuration files for clouds\n",  len(cloudFileList))
 
-	clouds := make(map[string]Cloud)
+	clouds := make(map[string]v1.Cloud)
 
 	for _, cloudFile := range(cloudFileList) {
 		content, err := ioutil.ReadFile(cloudFile)
@@ -53,7 +41,7 @@ func loadClouds() map[string]Cloud {
 			log.Err.Println("Error in loadClouds()")
 			log.Err.Fatal(err)
 		}
-		cloud := Cloud{Enabled: true}
+		cloud := v1.Cloud{Enabled: true}
 		err = yaml.Unmarshal(content, &cloud)
 		if err != nil {
 			log.Err.Println("Cannot read configuration of clouds.yml")
@@ -69,15 +57,17 @@ func loadClouds() map[string]Cloud {
 	return clouds
 }
 
-var clouds map[string]Cloud
-
+var clouds map[string]v1.Cloud
 
 // Public functions
 
+// Read the config from the local files and save in-memory
 func Load() {
+	// TODO: save and restore taints
 	clouds = loadClouds()
 }
 
-func GetClouds() map[string]Cloud {
+// GetClouds Returns the in-memory list of clouds (v1)
+func GetClouds() map[string]v1.Cloud {
 	return clouds
 }

--- a/scheduler/modules/labels.go
+++ b/scheduler/modules/labels.go
@@ -1,13 +1,13 @@
 package modules
 
 import (
-	"github.com/redhat-gpe/scheduler/config"
+	"github.com/redhat-gpe/scheduler/api/v1"
 	"sort"
 	"math/rand"
 )
 
-func LabelPredicates(clouds map[string]config.Cloud, labels map[string]string) map[string]config.Cloud {
-	result := map[string]config.Cloud{}
+func LabelPredicates(clouds map[string]v1.Cloud, labels map[string]string) map[string]v1.Cloud {
+	result := map[string]v1.Cloud{}
 
 out:
 	for k, v := range clouds {
@@ -25,15 +25,15 @@ out:
 
 // Priorities
 
-// ByLabels implements sort.Interface for []config.Cloud
+// ByLabels implements sort.Interface for []v1.Cloud
 // based on the weight
-type ByWeight []config.Cloud
+type ByWeight []v1.Cloud
 func (a ByWeight) Len() int           { return len(a) }
 func (a ByWeight) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 func (a ByWeight) Less(i, j int) bool { return a[i].Weight >= a[j].Weight }
 
-func applyPriorityWeight(clouds map[string]config.Cloud, preferences map[string]string) []config.Cloud {
-	result := []config.Cloud{}
+func applyPriorityWeight(clouds map[string]v1.Cloud, preferences map[string]string) []v1.Cloud {
+	result := []v1.Cloud{}
 	for _, v := range clouds {
 		for kp, vp := range preferences {
 			if vl, ok := v.Labels[kp]; ok {
@@ -48,7 +48,7 @@ func applyPriorityWeight(clouds map[string]config.Cloud, preferences map[string]
 }
 
 
-func LabelPriorities(clouds map[string]config.Cloud, preferences map[string]string) []config.Cloud {
+func LabelPriorities(clouds map[string]v1.Cloud, preferences map[string]string) []v1.Cloud {
 	result := applyPriorityWeight(clouds, preferences)
 	rand.Shuffle(len(result), func(i, j int) {
 		result[i], result[j] = result[j], result[i]

--- a/scheduler/modules/labels_test.go
+++ b/scheduler/modules/labels_test.go
@@ -1,18 +1,18 @@
 package modules
 
 import (
-	"github.com/redhat-gpe/scheduler/config"
+	"github.com/redhat-gpe/scheduler/api/v1"
 	"testing"
 )
 
 func TestLabelPredicates(t *testing.T) {
 	var (
 		labels map[string]string
-		clouds map[string]config.Cloud
-		result map[string]config.Cloud
+		clouds map[string]v1.Cloud
+		result map[string]v1.Cloud
 	)
-	clouds = map[string]config.Cloud{
-		"openstack-1": config.Cloud{
+	clouds = map[string]v1.Cloud{
+		"openstack-1": v1.Cloud{
 			Name: "openstack-1",
 			Labels: map[string]string{
 				"type": "osp",
@@ -20,7 +20,7 @@ func TestLabelPredicates(t *testing.T) {
 				"purpose": "development",
 			},
 		},
-		"openstack-2": config.Cloud{
+		"openstack-2": v1.Cloud{
 			Name: "openstack-2",
 			Labels: map[string]string{
 				"type": "osp",
@@ -28,7 +28,7 @@ func TestLabelPredicates(t *testing.T) {
 				"purpose": "ILT",
 			},
 		},
-		"openstack-3": config.Cloud{
+		"openstack-3": v1.Cloud{
 			Name: "openstack-3",
 			Labels: map[string]string{
 				"type": "osp",
@@ -86,12 +86,12 @@ func TestLabelPredicates(t *testing.T) {
 func TestLabelPriorities(t *testing.T) {
 	var (
 		preferences map[string]string
-		clouds map[string]config.Cloud
-		result []config.Cloud
+		clouds map[string]v1.Cloud
+		result []v1.Cloud
 	)
 
-	clouds = map[string]config.Cloud{
-		"openstack-1": config.Cloud{
+	clouds = map[string]v1.Cloud{
+		"openstack-1": v1.Cloud{
 			Name: "openstack-1",
 			Labels: map[string]string{
 				"type": "osp",
@@ -99,7 +99,7 @@ func TestLabelPriorities(t *testing.T) {
 				"purpose": "development",
 			},
 		},
-		"openstack-2": config.Cloud{
+		"openstack-2": v1.Cloud{
 			Name: "openstack-2",
 			Labels: map[string]string{
 				"type": "osp",
@@ -107,7 +107,7 @@ func TestLabelPriorities(t *testing.T) {
 				"purpose": "ILT",
 			},
 		},
-		"openstack-3": config.Cloud{
+		"openstack-3": v1.Cloud{
 			Name: "openstack-3",
 			Labels: map[string]string{
 				"type": "osp",
@@ -115,7 +115,7 @@ func TestLabelPriorities(t *testing.T) {
 				"purpose": "ELT",
 			},
 		},
-		"openstack-4": config.Cloud{
+		"openstack-4": v1.Cloud{
 			Name: "openstack-4",
 			Labels: map[string]string{
 				"type": "osp",
@@ -123,7 +123,7 @@ func TestLabelPriorities(t *testing.T) {
 				"purpose": "ELT",
 			},
 		},
-		"openstack-5": config.Cloud{
+		"openstack-5": v1.Cloud{
 			Name: "openstack-5",
 			Labels: map[string]string{
 				"type": "osp",
@@ -131,7 +131,7 @@ func TestLabelPriorities(t *testing.T) {
 				"purpose": "development",
 			},
 		},
-		"openstack-6": config.Cloud{
+		"openstack-6": v1.Cloud{
 			Name: "openstack-6",
 			Labels: map[string]string{
 				"type": "osp",

--- a/scheduler/modules/taints.go
+++ b/scheduler/modules/taints.go
@@ -1,0 +1,40 @@
+package modules
+
+import (
+	"github.com/redhat-gpe/scheduler/api/v1"
+)
+
+type taintedCloud v1.Cloud
+
+func (c taintedCloud) isTolerated(tolerations []v1.Toleration) bool {
+taintLoop:
+	for _, taint := range c.Taints {
+		// Ignore Taint if effect is not NoSchedule
+		if taint.Effect != v1.TaintEffectNoSchedule {
+			continue taintLoop
+		}
+	tolerationLoop:
+		for _, tol := range tolerations {
+			if tol.ToleratesTaint(taint) {
+				continue taintLoop
+			} else {
+				continue tolerationLoop
+			}
+		}
+
+		return false
+	}
+	return true
+}
+
+// This function filters out clouds with taints unless there are matching tolerations.
+func TaintPredicates(clouds map[string]v1.Cloud, tolerations []v1.Toleration) map[string]v1.Cloud {
+	result := map[string]v1.Cloud{}
+
+	for k, v := range clouds {
+		if (taintedCloud)(v).isTolerated(tolerations) {
+			result[k] = v
+		}
+	}
+	return result
+}

--- a/scheduler/modules/taints_test.go
+++ b/scheduler/modules/taints_test.go
@@ -1,0 +1,186 @@
+package modules
+
+import (
+	"testing"
+	"github.com/redhat-gpe/scheduler/api/v1"
+	"sort"
+)
+
+// Equal tells whether a and b contain the same elements.
+// A nil argument is equivalent to an empty slice.
+func sliceEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if v != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestTaintPredicates (t *testing.T) {
+	clouds := map[string]v1.Cloud{
+		"openstack-1": v1.Cloud{
+			Name: "openstack-1",
+			Taints: map[string]v1.Taint{},
+		},
+		"openstack-2": v1.Cloud{
+			Name: "openstack-2",
+			Taints: map[string]v1.Taint{
+				"memory-pressure": {
+					Key: "memory-pressure",
+					Value: "high",
+					Effect: v1.TaintEffectPreferNoSchedule,
+				},
+			},
+		},
+		"openstack-3": v1.Cloud{
+			Name: "openstack-3",
+			Taints: map[string]v1.Taint{
+				"memory-pressure": {
+					Key: "memory-pressure",
+					Value: "critical",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+			},
+		},
+		"openstack-4": v1.Cloud{
+			Name: "openstack-4",
+			Taints: map[string]v1.Taint{
+				"custom-taint": {
+					Key: "custom-taint",
+					Value: "custom-value",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+			},
+		},
+		"openstack-5": v1.Cloud{
+			Name: "openstack-5",
+			Taints: map[string]v1.Taint{
+				"cpu-pressure": {
+					Key: "cpu-pressure",
+					Value: "critical",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+			},
+		},
+		"openstack-6": v1.Cloud{
+			Name: "openstack-6",
+			Taints: map[string]v1.Taint{
+				"disk-pressure": {
+					Key: "disk-pressure",
+					Value: "high",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+			},
+		},
+		"openstack-7": v1.Cloud{
+			Name: "openstack-7",
+			Taints: map[string]v1.Taint{
+				"disk-pressure": {
+					Key: "disk-pressure",
+					Value: "critical",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+			},
+		},
+		"openstack-8": v1.Cloud{
+			Name: "openstack-8",
+			Taints: map[string]v1.Taint{
+				"disk-pressure": {
+					Key: "disk-pressure",
+					Value: "critical",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+				"memory-pressure": {
+					Key: "memory-pressure",
+					Value: "critical",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+			},
+		},
+	}
+	testCases := []struct {
+		description string
+		clouds map[string]v1.Cloud
+		tolerations []v1.Toleration
+		expected []string
+	}{
+		{
+			description: "No tolerations",
+			clouds: clouds,
+			tolerations: []v1.Toleration{},
+			expected: []string{
+				"openstack-1",
+				"openstack-2",
+			},
+		},
+		{
+			description: "Toleration memory-pressure exists",
+			clouds: clouds,
+			tolerations: []v1.Toleration{
+				{
+					Key: "memory-pressure",
+					Operator: "Exists",
+				},
+			},
+			expected: []string{
+				"openstack-1",
+				"openstack-2",
+				"openstack-3",
+			},
+		},
+		{
+			description: "",
+			clouds: clouds,
+			tolerations: []v1.Toleration{
+				{
+					Key: "disk-pressure",
+					Value: "critical",
+					Operator: "Equal",
+				},
+			},
+			expected: []string{
+				"openstack-1",
+				"openstack-2",
+				"openstack-7",
+			},
+		},
+		{
+			description: "",
+			clouds: clouds,
+			tolerations: []v1.Toleration{
+				{
+					Operator: "Exists",
+				},
+			},
+			expected: []string{
+				"openstack-1",
+				"openstack-2",
+				"openstack-3",
+				"openstack-4",
+				"openstack-5",
+				"openstack-6",
+				"openstack-7",
+				"openstack-8",
+			},
+		},
+
+	}
+
+	for _, c := range testCases {
+		rclouds := TaintPredicates(c.clouds, c.tolerations)
+
+		r := []string{}
+		for _, v := range rclouds {
+			r = append(r, v.Name)
+		}
+		sort.Strings(r)
+
+		if !sliceEqual(r, c.expected) {
+                        t.Errorf("'%s', Expected TaintPredicates() to be %v but it was %v", c.description, c.expected, r)
+		}
+	}
+}


### PR DESCRIPTION
- Move types to api/v1
  Types are needed in a lot of packages. To avoid cycle loops, create them in
  api/v1.
  Plus, it makes sense that the types and their structures are versioned with the API.
- Introduce Taints & Tolerations (works the same as in the OpenShift Scheduler)
- Add unit tests for Taints & Tolerations