### PR TITLE
Add placements and the ability to retrieve one using UUID

### DIFF
--- a/docs/api-reference/swagger.yaml
+++ b/docs/api-reference/swagger.yaml
@@ -47,7 +47,7 @@ paths:
                 $ref: "#/components/schemas/Error"
   /schedule:
     post:
-      summary: Request schedule of all available clouds matching selector (predicates with labels) and preferences (priorities with labels)
+      summary: Request a deployment to be scheduled on one of all available clouds matching selector (predicates with labels) and preferences (priorities with labels).
       operationId: schedule
       tags:
         - schedule
@@ -59,11 +59,17 @@ paths:
               $ref: "#/components/schemas/CloudQuery"
       responses:
         '200':
-          description: The cloud you can use to deploy.
+          description: The Placement given by the scheduler, containing the target cloud that can be used.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Cloud"
+                $ref: "#/components/schemas/Placement"
+        '400':
+          description: The service identified by uuid already has a placement.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
         '404':
           description: NotFound
           content:
@@ -76,6 +82,86 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+  /placements:
+    get:
+      summary: List all the placements.
+      tags:
+        - schedule
+      responses:
+        '200':
+          description: All the placements assigned.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Placements"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /placements/{uuid}:
+    get:
+      summary: Get the placement assigned to a specific uuid. This is used before starting / stopping / destroying a service, to know on what cloud it was scheduled to.
+      tags:
+        - schedule
+      parameters:
+        - name: uuid
+          in: path
+          required: true
+          description: The UUID of the service in CloudForms.
+          schema:
+            $ref: "#/components/schemas/UUID"
+      responses:
+        '200':
+          description: The placement assigned to this uuid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Placement"
+        '404':
+          description: Placement not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    delete:
+      summary: Delete the placement assigned to a specific uuid. You usually call this endpoint once your service is destroyed.
+      tags:
+        - schedule
+      parameters:
+        - name: uuid
+          in: path
+          required: true
+          description: The UUID of the service in CloudForms.
+          schema:
+            $ref: "#/components/schemas/UUID"
+      responses:
+        '200':
+          description: The placement assigned to this uuid is deleted.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Placement"
+        '404':
+          description: Placement not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
   /clouds:
     get:
       summary: List all clouds
@@ -130,6 +216,7 @@ paths:
 components:
   schemas:
     Cloud:
+      description: Object that defines a Cloud.
       type: object
       required:
         - name
@@ -141,13 +228,46 @@ components:
           type: object
           additionalProperties:
             type: string
+
     Clouds:
       type: array
       items:
         $ref: "#/components/schemas/Cloud"
+
+    UUID:
+      type: string
+      description: The UUID of the service in CloudForms. It used to identify placement and can be used later to retrieve a placement.
+      format: uuid
+
+    Placement:
+      type: object
+      description: A placement is a record of what(uuid) / where(cloud) / when(date) something was scheduled.
+      required:
+        - uuid
+        - cloud
+        - date
+      properties:
+        uuid:
+          $ref: "#/components/schemas/UUID"
+        cloud:
+          $ref: "#/components/schemas/Cloud"
+        date:
+          description: The date (UTC and RFC3339 format) the placement was made.
+          type: string
+          format: date-time
+
+    Placements:
+      type: array
+      items:
+        $ref: "#/components/schemas/Placement"
+
     CloudQuery:
       type: object
+      required:
+        - uuid
       properties:
+        uuid:
+          $ref: "#/components/schemas/UUID"
         cloud_selector:
           description: This dictionary describes the labels (key:value) that must be present in the clouds in order to be selected by the scheduler.
           type: object

--- a/scheduler/api/api.go
+++ b/scheduler/api/api.go
@@ -23,7 +23,10 @@ func Serve() {
 	router.GET("/api/v1/clouds/:name", v1GetCloudByName)
 	router.GET("/api/v1/repo", v1GetRepository)
 	router.PUT("/api/v1/repo", v1PullRepository)
-	router.POST("/api/v1/schedule", v1Schedule)
+	router.POST("/api/v1/schedule", v1PostSchedule)
+	router.GET("/api/v1/placements", v1GetPlacements)
+	router.GET("/api/v1/placements/:uuid", v1GetPlacement)
+	router.DELETE("/api/v1/placements/:uuid", v1DeletePlacement)
 
 	log.Fatal(http.ListenAndServe(":8080", router))
 }

--- a/scheduler/api/handlers.go
+++ b/scheduler/api/handlers.go
@@ -9,6 +9,7 @@ import (
 	"github.com/redhat-gpe/scheduler/modules"
 	"github.com/redhat-gpe/scheduler/watcher"
 	"github.com/redhat-gpe/scheduler/api/v1"
+	"github.com/redhat-gpe/scheduler/placement"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -17,144 +18,276 @@ import (
 )
 
 func v1GetClouds(w http.ResponseWriter, req *http.Request, params httprouter.Params) {
-	jsonResult, err := json.MarshalIndent(config.GetClouds(), "", "  ")
-	if err != nil {
-		log.Err.Println(err)
-		errorMessage := v1.Error{
-			Code: 1,
-			Message: "Error reading clouds from config.",
-		}
-		jsonError, _ := json.MarshalIndent(errorMessage, "", " ")
+	w.Header().Set("Content-Type", "application/json")
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", " ")
+	clouds := []v1.Cloud{}
+	for _, v := range config.GetClouds() {
+		clouds = append(clouds, v)
+	}
+	if err := enc.Encode(clouds); err != nil {
+		log.Err.Println("GET clouds", err)
 		w.WriteHeader(http.StatusInternalServerError)
-		io.WriteString(w, string(jsonError))
-	} else {
-		io.WriteString(w, string(jsonResult))
+		enc.Encode(v1.Error{
+			Code: 500,
+			Message: "Error reading clouds from config.",
+		})
 	}
 }
 
-func v1Schedule(w http.ResponseWriter, req *http.Request, params httprouter.Params) {
+func v1PostSchedule(w http.ResponseWriter, req *http.Request, params httprouter.Params) {
+	w.Header().Set("Content-Type", "application/json")
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", " ")
+
 	body, err := ioutil.ReadAll(req.Body)
 	if err != nil {
-		log.Err.Println(err)
-		errorMessage := v1.Error{
+		w.WriteHeader(http.StatusBadRequest)
+		log.Err.Println("POST schedule", err)
+		enc.Encode(v1.Error{
 			Code: http.StatusBadRequest,
 			Message: "Error reading body from request.",
-		}
-		jsonError, _ := json.MarshalIndent(errorMessage, "", " ")
-		w.WriteHeader(http.StatusBadRequest)
-		io.WriteString(w, string(jsonError))
+		})
 		return
 	}
-	log.Debug.Println(string(body))
+	log.Out.Println("POST schedule, Body received: ", string(body))
 
 	if ! json.Valid([]byte(body)) {
-		errorMessage := v1.Error{
+		w.WriteHeader(http.StatusBadRequest)
+		enc.Encode(v1.Error{
 			Code: http.StatusBadRequest,
 			Message: "Body is not valid JSON.",
-		}
-		jsonError, _ := json.MarshalIndent(errorMessage, "", " ")
-		w.WriteHeader(http.StatusBadRequest)
-		io.WriteString(w, string(jsonError))
+		})
 		return
 	}
-
 
 	dec := json.NewDecoder(strings.NewReader(string(body)))
 	dec.DisallowUnknownFields()
-
 	t := new(v1.CloudQuery)
 	if err := dec.Decode(t); err != io.EOF  && err != nil {
-		log.Err.Println(err)
-		errorMessage := v1.Error{
+		log.Out.Println("POST schedule", err)
+		w.WriteHeader(http.StatusBadRequest)
+		enc.Encode(v1.Error{
 			Code: http.StatusBadRequest,
 			Message: "Error reading data from body. "+err.Error(),
-		}
-		jsonError, _ := json.MarshalIndent(errorMessage, "", " ")
-		w.WriteHeader(http.StatusBadRequest)
-		io.WriteString(w, string(jsonError))
+		})
 		return
 	}
 
-	log.Debug.Println(t, "bla", t.CloudSelector)
+	if t.UUID == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		enc.Encode(v1.Error{
+			Code: http.StatusBadRequest,
+			Message: "uuid must be provided",
+		})
+		return
+	}
+
+	if _, err := placement.Get(t.UUID) ; err != placement.ErrPlacementNotFound {
+		if err == nil {
+			w.WriteHeader(http.StatusBadRequest)
+			enc.Encode(v1.Error{
+				Code: http.StatusBadRequest,
+				Message: "This service uuid already has a placement",
+			})
+			return
+
+		}
+		// Else something went wrong
+		log.Err.Println("POST schedule", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		enc.Encode(v1.Error{
+			Code: 500,
+			Message: "Internal Server Error",
+		})
+		return
+	}
 
 	clouds := modules.LabelPredicates(config.GetClouds(), t.CloudSelector)
-	result := modules.LabelPriorities(clouds, t.CloudPreference)
-
-	if len(result) == 0 {
-		log.Err.Println(err)
-		errorMessage := v1.Error{
+	results := modules.LabelPriorities(clouds, t.CloudPreference)
+	if len(results) == 0 {
+		log.Out.Println("POST schedule", err)
+		enc.Encode(v1.Error{
 			Code: 404,
 			Message: "No cloud found.",
-		}
-		jsonError, _ := json.MarshalIndent(errorMessage, "", " ")
-		w.WriteHeader(http.StatusNotFound)
-		io.WriteString(w, string(jsonError))
+		})
 		return
 	}
-
-	// Pick the first one
-	jsonResult, err := json.MarshalIndent(result[0], "", "  ")
-	if err != nil {
-		log.Err.Println(err)
-		errorMessage := v1.Error{
-			Code: 4,
-			Message: "Error marshaling cloud from config to JSON.",
-		}
-		jsonError, _ := json.MarshalIndent(errorMessage, "", " ")
+	// pick the first one
+	result := v1.Placement{
+		UUID: t.UUID,
+		Cloud: results[0],
+		Date: time.Now().UTC().Format(time.RFC3339),
+	}
+	placement.Save(result)
+	if err := enc.Encode(result) ; err != nil {
+		log.Err.Println("POST schedule", err)
 		w.WriteHeader(http.StatusInternalServerError)
-		io.WriteString(w, string(jsonError))
+		enc.Encode(v1.Error{
+			Code: 500,
+			Message: "Error encoding data to JSON",
+		})
+	}
+}
+
+func v1GetPlacements(w http.ResponseWriter, req *http.Request, params httprouter.Params) {
+	w.Header().Set("Content-Type", "application/json")
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", " ")
+	if p, err := placement.GetAll() ; err == nil {
+		log.Debug.Println("GET placement", p)
+		if err := enc.Encode(p); err != nil {
+			log.Err.Println("GET placement", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			enc.Encode(v1.Error{
+				Code: 500,
+				Message: "Marshal JSON error",
+			})
+			return
+		}
 	} else {
-		io.WriteString(w, string(jsonResult))
+		log.Err.Println("GET placement", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		enc.Encode(v1.Error{
+			Code: 500,
+			Message: "Internal Server Error",
+		})
+	}
+}
+
+func v1GetPlacement(w http.ResponseWriter, req *http.Request, params httprouter.Params) {
+	w.Header().Set("Content-Type", "application/json")
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", " ")
+	uuid := params.ByName("uuid")
+	if uuid == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		enc.Encode(v1.Error{
+			Code: 400,
+			Message: "UUID must be specified in the request",
+		})
+		return
+	}
+	if p, err := placement.Get(uuid) ; err == nil {
+		log.Debug.Println("GET placement", p)
+		if err := enc.Encode(p); err != nil {
+			log.Err.Println("GET placement", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			enc.Encode(v1.Error{
+				Code: 500,
+				Message: "Marshal JSON error",
+			})
+			return
+		}
+	} else if err == placement.ErrPlacementNotFound {
+		w.WriteHeader(http.StatusNotFound)
+		enc.Encode(v1.Error{
+			Code: 404,
+			Message: "Placement not found.",
+		})
+	} else {
+		log.Err.Println("GET placement", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		enc.Encode(v1.Error{
+			Code: 500,
+			Message: "Internal Server Error",
+		})
+	}
+}
+
+func v1DeletePlacement(w http.ResponseWriter, req *http.Request, params httprouter.Params) {
+	w.Header().Set("Content-Type", "application/json")
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", " ")
+	uuid := params.ByName("uuid")
+	if uuid == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		enc.Encode(v1.Error{
+			Code: 400,
+			Message: "UUID must be specified in the request",
+		})
+		return
+	}
+	if _, err := placement.Get(uuid) ; err == nil {
+		log.Debug.Println("DELETE placement", uuid)
+		if err := placement.Delete(uuid) ; err == nil {
+			enc.Encode(v1.Message{
+				Message: "placement deleted",
+			})
+		} else {
+			w.WriteHeader(http.StatusInternalServerError)
+			log.Err.Println("DELETE placement", err)
+			enc.Encode(v1.Error{
+				Code: 500,
+				Message: "error deleting placement",
+			})
+			return
+		}
+	} else if err == placement.ErrPlacementNotFound {
+		w.WriteHeader(http.StatusNotFound)
+		enc.Encode(v1.Error{
+			Code: 404,
+			Message: "Placement not found.",
+		})
+	} else {
+		w.WriteHeader(http.StatusInternalServerError)
+		log.Err.Println("DELETE placement", err)
+		enc.Encode(v1.Error{
+			Code: 500,
+			Message: "Internal Server Error",
+		})
 	}
 }
 
 func v1GetCloudByName(w http.ResponseWriter, req *http.Request, params httprouter.Params) {
+	w.Header().Set("Content-Type", "application/json")
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", " ")
 	clouds := config.GetClouds()
 	if val, ok := clouds[params.ByName("name")] ; ok {
-		json, err := json.MarshalIndent(val, "", "  ")
-		if err != nil {
-			log.Err.Println(err)
-			io.WriteString(w, "Error\n")
-		} else {
-			io.WriteString(w, string(json))
+		if err := enc.Encode(val); err != nil {
+			log.Err.Println("GET cloud", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			enc.Encode(v1.Error{
+				Code: 500,
+				Message: "Marshal JSON error",
+			})
 		}
+		return
 
-	} else {
-		errorMessage := v1.Error{
-			Code: 404,
-			Message: "Cloud not found.",
-		}
-		jsonError, _ := json.MarshalIndent(errorMessage, "", " ")
-		w.WriteHeader(http.StatusNotFound)
-		io.WriteString(w, string(jsonError))
 	}
+	w.WriteHeader(http.StatusNotFound)
+	enc.Encode(v1.Error{
+		Code: 404,
+		Message: "Cloud not found.",
+	})
 }
 
 func v1GetRepository(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
+	w.Header().Set("Content-Type", "application/json")
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", " ")
 	if head, err := git.GetRepoHeadCommit() ; err == nil {
-		m := v1.GitCommit{
+		enc.Encode(v1.GitCommit{
 			Hash: head.Hash.String(),
 			Author: head.Author.Name,
 			Date: head.Author.When.UTC().Format(time.RFC3339),
-		}
-		jsonReply, _ := json.MarshalIndent(m, "", " ")
-		io.WriteString(w, string(jsonReply))
+		})
 	} else {
-		errorMessage := v1.Error{
+		w.WriteHeader(http.StatusInternalServerError)
+		enc.Encode(v1.Error{
 			Code: http.StatusInternalServerError,
 			Message: "ERROR while retrieving Git HEAD information.",
-		}
-		jsonError, _ := json.MarshalIndent(errorMessage, "", " ")
-		w.WriteHeader(http.StatusInternalServerError)
-		io.WriteString(w, string(jsonError))
+		})
 	}
 }
 
 func v1PullRepository(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
+	w.Header().Set("Content-Type", "application/json")
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", " ")
 	go watcher.RequestPull()
-	m := v1.Message{
+	enc.Encode(v1.Message{
 		Message: "Request to update git repository received.",
-	}
-	jsonMessage, _ := json.MarshalIndent(m, "", " ")
-	io.WriteString(w, string(jsonMessage))
+	})
 }

--- a/scheduler/api/v1/types.go
+++ b/scheduler/api/v1/types.go
@@ -34,6 +34,7 @@ type Message struct {
 type CloudQuery struct {
 	CloudSelector map[string]string `json:"cloud_selector"`
 	CloudPreference map[string]string `json:"cloud_preference"`
+	UUID string `json:"uuid,omitempty"`
 }
 
 type GitCommit struct {
@@ -90,4 +91,14 @@ type Toleration struct {
 	// When specified, allowed values are NoSchedule, PreferNoSchedule.
 	// +optional
 	Effect string `json:"effect,omitempty"`
+}
+
+// Placement object to track where a deployment goes. The link is done thanks to uuid.
+type Placement struct {
+	// The uuid of the CloudForms service
+	UUID string `json:"uuid,omitempty"`
+	// Date the placement was made. UTF and RFC3339
+	Date string `json:"date"`
+	// The cloud where it was scheduled to.
+	Cloud Cloud `json:"cloud"`
 }

--- a/scheduler/git/git.go
+++ b/scheduler/git/git.go
@@ -20,6 +20,8 @@ var configRepoDir string
 var configRepoCloneOptions *git.CloneOptions
 var configRepoPullOptions *git.PullOptions
 
+var ErrUpdatedTooRecently = errors.New("updated too recently")
+
 // This function returns the current repository path as a string.
 func GetRepoDir() string {
 	return configRepoDir
@@ -110,7 +112,7 @@ func RefreshRepository() error {
 	// Do not spam git pull. Allow only one pull every 10 seconds for this process.
 	if time.Now().Sub(lastUpdated) < 10 * time.Second {
 		log.Debug.Println("Git repo updated recently. Ignoring.")
-		return errors.New("updated too recently")
+		return ErrUpdatedTooRecently
 	}
 	wt, err:= configRepo.Worktree()
 

--- a/scheduler/watcher/repo.go
+++ b/scheduler/watcher/repo.go
@@ -11,7 +11,7 @@ import(
 func RequestPull() {
 	conn, err :=  db.Dial()
 	if err != nil {
-		log.Debug.Println("Cannot connect to redis. Repo not updated.")
+		log.Err.Println("Cannot connect to redis. Repo not updated.")
 		return
 	}
 	defer conn.Close()


### PR DESCRIPTION
Introduce the use of UUID. When asking the scheduler for a cloud using the
/api/v1/schedule endpoint, the uuid of the service in cloudforms (or babylon)
must be passed.

That uuid will then be used later to retrieve the placement, for example, when
destroying the service.

This commit, if applied, make the following changes:
- Add a new type, Placement
- UUID is now mandatory for the /api/v1/schedule POST endpoint
- change the response for schedule from Cloud to Placement
- Add a new API endpoint /api/v1/placements to interact with placements
  - Get all
  - Get one using uuid
  - Delete one using uuid
- Change HTTP Header 'Content-Type' to 'application/json' in all handlers
- Use json.NewEncoder instead of manual Marshal, more readable and easier to use
- git package: Add new error type: ErrUpdatedTooRecently. Used to avoid pulling
  the repo too frequently