### PR TITLE
Add Taints and Tolerations

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -29,6 +29,42 @@ Usage of ./scheduler:
          (default "redis://localhost:6379")
 ----
 
+== Config Git repository ==
+
+The Git repository must contain the following:
+
+- `/policy.yaml` - describing the policy.
+- `/clouds` - directory containting the definition of the resources (clouds) to be scheduled.
+
+.example `policy.yaml`
+[source,yaml]
+----
+---
+predicates:
+  - name: LabelPredicates
+  - name: TaintPredicates
+
+priorities:
+  - name: LabelPriorities
+    weight: 1 # <1>
+  - name: TaintPriorities
+    weight: 1 # <2>
+----
+<1> The weight that will be used to increase the priority of Clouds that match the preferences provided in the Schedule request
+<2> The weight that will be used to decrease the priority of Clouds if they have Taints of type "PreferNoSchedule"
+
+.example `clouds/openstack-blue.yml`
+[source,yaml]
+----
+---
+name: openstack-blue
+labels:
+  type: osp
+  region: na
+  datacenter: wdc
+  purpose: ilt
+----
+
 == Example using the scheduler (client)
 
 Here is an example how the scheduler can be used from ansible.
@@ -55,6 +91,8 @@ agnosticv_meta:
 - name: Schedule or retrieve a placement using UUID
   hosts: localhost
   gather_facts: false
+  vars:
+    output: /tmp/placement.json
   tasks:
     - name: Schedule a placement
       uri:
@@ -65,6 +103,7 @@ agnosticv_meta:
         body_format: json
         body: "{{ agnosticv_meta.scheduler.data }}"
         status_code: [200, 400]
+        dest: "{{ output }}"
       register: r_placement
       retries: 10
       delay: 30
@@ -79,13 +118,19 @@ agnosticv_meta:
         validate_certs: "{{ agnosticv_meta.scheduler.validate_certs | default(false) }}"
         return_content: true
         method: GET
-      register: r_placement
+        dest: "{{ output }}"
+      register: g_placement
       retries: 10
       delay: 30
-      until: r_placement is succeeded
+      until: g_placement is succeeded
 
     - debug:
-        msg: "{{ r_placement.json.cloud.name }}"
+        msg: >-
+          {% if r_placement.json.cloud is defined %}
+          {{ r_placement.json.cloud.name }}
+          {% else %}
+          {{ r_placement.json.message }}: {{ g_placement.json.cloud.name }}
+          {% endif %}
 ----
 
 . Playbook to delete placement using UUID

--- a/README.adoc
+++ b/README.adoc
@@ -11,6 +11,14 @@ image::https://gpte-public.s3.amazonaws.com/agnostics/scheduler.png[width=100%]
 [source,subs="+quotes,verbatim,macros"]
 ----
 Usage of ./scheduler:
+  -api-addr string
+        The address API listens to.
+        Environment variable: *API_ADDR.
+         (default ":8080")
+  -console-addr string
+        The address the Console listens to.
+        Environment variable: *CONSOLE_ADDR*
+         (default ":8081")
   -debug
         Debug mode.
         Environment variable: *DEBUG*
@@ -27,6 +35,10 @@ Usage of ./scheduler:
         The URL to access redis. The format is described by the IANA specification for the scheme, see https://www.iana.org/assignments/uri-schemes/prov/redis
         Environment variable: *REDIS_URL*
          (default "redis://localhost:6379")
+  -template-dir string
+        The directory containing the golang templates for the Console.
+        Environment variable: *REDIS_URL*
+         (default "templates")
 ----
 
 == Config Git repository ==

--- a/README.adoc
+++ b/README.adoc
@@ -37,7 +37,7 @@ Usage of ./scheduler:
          (default "redis://localhost:6379")
   -template-dir string
         The directory containing the golang templates for the Console.
-        Environment variable: *REDIS_URL*
+        Environment variable: *TEMPLATE_DIR*
          (default "templates")
 ----
 

--- a/README.adoc
+++ b/README.adoc
@@ -13,7 +13,7 @@ image::https://gpte-public.s3.amazonaws.com/agnostics/scheduler.png[width=100%]
 Usage of ./scheduler:
   -api-addr string
         The address API listens to.
-        Environment variable: *API_ADDR.
+        Environment variable: *API_ADDR*
          (default ":8080")
   -console-addr string
         The address the Console listens to.

--- a/cmd/scheduler/main.go
+++ b/cmd/scheduler/main.go
@@ -18,6 +18,8 @@ var repositoryURL string
 var sshPrivateKey string
 var redisURL string
 var templateDir string
+var apiAddress string
+var consoleAddress string
 
 func parseFlags() {
 	flag.StringVar(&repositoryURL, "git-url", "git@github.com:redhat-gpe/scheduler-config.git", "The URL of the git repository where the scheduler will find its configuration. SSH is assumed, unless the URL starts with 'http'.\nEnvironment variable: GIT_URL\n")
@@ -25,6 +27,9 @@ func parseFlags() {
 	flag.StringVar(&redisURL, "redis-url", "redis://localhost:6379", "The URL to access redis. The format is described by the IANA specification for the scheme, see https://www.iana.org/assignments/uri-schemes/prov/redis\nEnvironment variable: REDIS_URL\n")
 	flag.BoolVar(&debugFlag, "debug", false, "Debug mode.\nEnvironment variable: DEBUG\n")
 	flag.StringVar(&templateDir, "template-dir", "templates", "The directory containing the golang templates for the Console.\nEnvironment variable: REDIS_URL\n")
+	flag.StringVar(&apiAddress, "api-addr", ":8080", "The address API listens to.\nEnvironment variable: API_ADDR\n")
+	flag.StringVar(&consoleAddress, "console-addr", ":8081", "The address the Console listens to.\nEnvironment variable: CONSOLE_ADDR\n")
+
 	flag.Parse()
 	if e := os.Getenv("GIT_URL"); e != "" {
 		repositoryURL = e
@@ -34,6 +39,12 @@ func parseFlags() {
 	}
 	if e := os.Getenv("REDIS_URL"); e != "" {
 		redisURL = e
+	}
+	if e := os.Getenv("API_ADDR"); e != "" {
+		apiAddress = e
+	}
+	if e := os.Getenv("CONSOLE_ADDR"); e != "" {
+		consoleAddress = e
 	}
 	if e := os.Getenv("DEBUG"); e != "" && e != "false" {
 		debugFlag = true
@@ -46,7 +57,8 @@ func main() {
 	db.InitContext(redisURL)
 	git.CloneRepository(repositoryURL, sshPrivateKey)
 	go watcher.ConsumePullQueue()
+	go watcher.ConsumeTaintSyncQueue()
 	config.Load()
-	go console.Serve(templateDir)
-	api.Serve()
+	go console.Serve(templateDir, consoleAddress)
+	api.Serve(apiAddress)
 }

--- a/cmd/scheduler/main.go
+++ b/cmd/scheduler/main.go
@@ -26,7 +26,7 @@ func parseFlags() {
 	flag.StringVar(&sshPrivateKey, "git-ssh-private-key", "", "The path of the SSH private key used to authenticate to the git repository. Used only when 'git-url' is an SSH URL.\nEnvironment variable: GIT_SSH_PRIVATE_KEY\n")
 	flag.StringVar(&redisURL, "redis-url", "redis://localhost:6379", "The URL to access redis. The format is described by the IANA specification for the scheme, see https://www.iana.org/assignments/uri-schemes/prov/redis\nEnvironment variable: REDIS_URL\n")
 	flag.BoolVar(&debugFlag, "debug", false, "Debug mode.\nEnvironment variable: DEBUG\n")
-	flag.StringVar(&templateDir, "template-dir", "templates", "The directory containing the golang templates for the Console.\nEnvironment variable: REDIS_URL\n")
+	flag.StringVar(&templateDir, "template-dir", "templates", "The directory containing the golang templates for the Console.\nEnvironment variable: TEMPLATE_DIR\n")
 	flag.StringVar(&apiAddress, "api-addr", ":8080", "The address API listens to.\nEnvironment variable: API_ADDR\n")
 	flag.StringVar(&consoleAddress, "console-addr", ":8081", "The address the Console listens to.\nEnvironment variable: CONSOLE_ADDR\n")
 
@@ -45,6 +45,9 @@ func parseFlags() {
 	}
 	if e := os.Getenv("CONSOLE_ADDR"); e != "" {
 		consoleAddress = e
+	}
+	if e := os.Getenv("TEMPLATE_DIR"); e != "" {
+		templateDir = e
 	}
 	if e := os.Getenv("DEBUG"); e != "" && e != "false" {
 		debugFlag = true

--- a/docs/api-reference/swagger.yaml
+++ b/docs/api-reference/swagger.yaml
@@ -1,11 +1,11 @@
 openapi: "3.0.3"
 info:
-  version: 1.0.1
+  version: 1.0.2
   title: Scheduler
   license:
     name: MIT
 servers:
-  - url: http://scheduler.open.redhat.com/api/v1
+  - url: http://localhost:8080/api/v1
 paths:
   /repo:
     get:
@@ -52,7 +52,7 @@ paths:
       tags:
         - schedule
       requestBody:
-        description: JSON object to specify selectors and priorities
+        description: JSON object to specify selectors, priorities and tolerations
         content:
           application/json:
             schema:
@@ -213,6 +213,179 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+  /taint/{cloudName}:
+    post:
+      summary: Taint a cloud
+      operationId: taintCloud
+      tags:
+        - clouds
+      parameters:
+        - name: cloudName
+          in: path
+          required: true
+          description: The name of the cloud to taint
+          schema:
+            type: string
+      requestBody:
+        description: JSON object representing the taint
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Taint"
+      responses:
+        '200':
+          description: The cloud is tainted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Cloud"
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        '404':
+          description: Cloud NotFound
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /taint/{cloudName}/delete:
+    post:
+      summary: Untaint a cloud by passing the Taint in Body
+      operationId: deleteTaintByBody
+      tags:
+        - clouds
+      parameters:
+        - name: cloudName
+          in: path
+          required: true
+          description: The name of the cloud to untaint
+          schema:
+            type: string
+      requestBody:
+        description: JSON object representing the taint
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Taint"
+      responses:
+        '200':
+          description: Taint removed from cloud
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Cloud"
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        '404':
+          description: Cloud NotFound
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /taint/{cloudName}/{taintIndex}:
+    delete:
+      summary: Untaint a cloud by specifying the index of the taint to be removed
+      description: You can use this method to delete a taint from a cloud by providing the index of the taint in the <code>Cloud.Taints</code> array.
+      operationId: deleteTaintByIndex
+      tags:
+        - clouds
+      parameters:
+        - name: cloudName
+          in: path
+          required: true
+          description: The name of the cloud to untaint
+          schema:
+            type: string
+        - name: taintIndex
+          in: path
+          required: true
+          description: The index of the taint in the cloud
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          description: Taint was removed from cloud.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Cloud"
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        '404':
+          description: Cloud Not Found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /taints/{cloudName}:
+    delete:
+      summary: Untaint entirely a cloud, remove all its taints.
+      operationId: untaintCloud
+      tags:
+        - clouds
+      parameters:
+        - name: cloudName
+          in: path
+          required: true
+          description: The name of the cloud to untaint
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Cloud untainted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Cloud"
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        '404':
+          description: Cloud Not Found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
   /counters:
     put:
       summary: Force the server to refresh all the counters
@@ -240,7 +413,7 @@ components:
       type: object
       required:
         - name
-        - label
+        - labels
       properties:
         name:
           type: string
@@ -248,6 +421,10 @@ components:
           type: object
           additionalProperties:
             type: string
+        taints:
+          type: array
+          items:
+            $ref: "#/components/schemas/Taint"
 
     Clouds:
       type: array
@@ -290,6 +467,31 @@ components:
       items:
         $ref: "#/components/schemas/Placement"
 
+    Taint:
+      type: object
+      description: The cloud this taint is attached to has the "effect" on any deployment that does not tolerate the Taint.
+      required:
+        - key
+        - effect
+      properties:
+        key:
+          type: string
+          description: The name of the taint to be applied to a cloud.
+          example: memory-pressure
+        value:
+          type: string
+          description: The value of the taint.
+          example: critical
+        effect:
+          type: string
+          description: |-
+            The effect of the taint on deployments that do not tolerate the taint. <br /><br />
+            NoSchedule: affects the predicates, Cloud can't be selected unless there is a matching Toleration.
+            PreferNoSchedule: affects the priorities, Cloud will be de-prioritized.
+          enum:
+            - NoSchedule
+            - PreferNoSchedule
+
     Toleration:
       type: object
       description: Object passed when requesting schedule to ignore taints.
@@ -302,13 +504,20 @@ components:
             If the key is empty, operator must be Exists;
             this combination means to match all values and all keys.
             (optional)
+          example: memory-pressure
         operator:
           description: |-
             Operator represents a key's relationship to the value.
             Valid operators are Exists and Equal. Defaults to Equal.
             Exists is equivalent to wildcard for value, so that a cloud can
             tolerate all taints of a particular category.
-            (optional)
+            (optional)<br /><br />
+            Equal: The key/value/effect parameters must match. This is the default.<br />
+            Exists: The key/value/effect parameters must match. This is the default.
+          enum:
+            - Exists
+            - Equal
+          default: Equal
           type: string
         value:
           type: string
@@ -316,12 +525,16 @@ components:
             Value is the taint value the toleration matches to.
             If the operator is Exists, the value should be empty, otherwise just a regular string.
             +optional
+          example: critical
         effect:
           type: string
           description: |-
             Effect indicates the taint effect to match. Empty means match all taint effects.
             When specified, allowed values are NoSchedule, PreferNoSchedule.
             +optional
+          enum:
+            - NoSchedule
+            - PreferNoSchedule
 
     ScheduleQuery:
       type: object
@@ -342,7 +555,7 @@ components:
             type: string
         tolerations:
           type: array
-          description: The list of tolerations for this request. Any taint matching the a toleration will be ignored (all taints ignored == cloud can be selected).
+          description: The list of tolerations for this request. Any taint matching a toleration will be ignored (all taints ignored == cloud can be selected).
           items:
             $ref: "#/components/schemas/Toleration"
         annotations:

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -20,7 +20,7 @@ func healthHandler (w http.ResponseWriter, req *http.Request, _ httprouter.Param
 	io.WriteString(w, "OK\n")
 }
 
-func Serve() {
+func Serve(addr string) {
 	router := httprouter.New()
 
 	// Health and status checks
@@ -32,6 +32,10 @@ func Serve() {
 	// v1
 	router.GET("/api/v1/clouds", v1GetClouds)
 	router.GET("/api/v1/clouds/:name", v1GetCloudByName)
+	router.POST("/api/v1/taint/:cloudname", v1PostTaintByCloudName)
+	router.POST("/api/v1/taint/:cloudname/delete", v1DeleteTaintByCloudName)
+	router.DELETE("/api/v1/taint/:cloudname/:taintindex", v1DeleteTaintByIndex)
+	router.DELETE("/api/v1/taints/:cloudname", v1DeleteTaintsByCloudName)
 	router.GET("/api/v1/repo", v1GetRepository)
 	router.PUT("/api/v1/repo", v1PullRepository)
 	router.POST("/api/v1/schedule", v1PostSchedule)
@@ -40,6 +44,6 @@ func Serve() {
 	router.DELETE("/api/v1/placements/:uuid", v1DeletePlacement)
 	router.PUT("/api/v1/counters", v1PutCounters)
 
-	log.Out.Println("API listen on port :8080")
-	log.Err.Fatal(http.ListenAndServe(":8080", router))
+	log.Out.Println("API listen on port", addr)
+	log.Err.Fatal(http.ListenAndServe(addr, router))
 }

--- a/internal/api/handlers_taint.go
+++ b/internal/api/handlers_taint.go
@@ -1,0 +1,338 @@
+package api
+
+import (
+	"strconv"
+	"encoding/json"
+	"github.com/julienschmidt/httprouter"
+	"github.com/redhat-gpe/agnostics/internal/config"
+	"github.com/redhat-gpe/agnostics/internal/log"
+	"github.com/redhat-gpe/agnostics/internal/watcher"
+	"github.com/redhat-gpe/agnostics/internal/db"
+	"github.com/redhat-gpe/agnostics/internal/api/v1"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"fmt"
+)
+
+func v1PostTaintByCloudName(w http.ResponseWriter, req *http.Request, params httprouter.Params) {
+	functionName := "v1PostTaintByCloudName:"
+	w.Header().Set("Content-Type", "application/json")
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", " ")
+	cloudName := params.ByName("cloudname")
+	if cloudName == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		enc.Encode(v1.Error{
+			Code: 400,
+			Message: "Cloud name must be specified in the request",
+		})
+		return
+	}
+
+	body, err := ioutil.ReadAll(req.Body)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		log.Err.Println("POST schedule", err)
+		enc.Encode(v1.Error{
+			Code: http.StatusBadRequest,
+			Message: "Error reading body from request.",
+		})
+		return
+	}
+	log.Out.Println(functionName, "Body received: ", string(body))
+
+	if ! json.Valid([]byte(body)) {
+		w.WriteHeader(http.StatusBadRequest)
+		enc.Encode(v1.Error{
+			Code: http.StatusBadRequest,
+			Message: "Body is not valid JSON.",
+		})
+		return
+	}
+
+	dec := json.NewDecoder(strings.NewReader(string(body)))
+	dec.DisallowUnknownFields()
+	t := v1.NewTaint()
+	if err := dec.Decode(&t); err != io.EOF  && err != nil {
+		log.Out.Println(functionName, err)
+		w.WriteHeader(http.StatusBadRequest)
+		enc.Encode(v1.Error{
+			Code: http.StatusBadRequest,
+			Message: "Error reading data from body. "+err.Error(),
+		})
+		return
+	}
+
+	if t.Key == "" || t.Effect == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		enc.Encode(v1.Error{
+			Code: http.StatusBadRequest,
+			Message: "Taint must have 'key' and 'effect'. ",
+		})
+		return
+	}
+
+	if t.Effect != v1.TaintEffectNoSchedule && t.Effect != v1.TaintEffectPreferNoSchedule {
+		w.WriteHeader(http.StatusBadRequest)
+		enc.Encode(v1.Error{
+			Code: http.StatusBadRequest,
+			Message: "Taint.effect must be 'NoSchedule' or 'PreferNoSchedule'. ",
+		})
+		return
+	}
+
+	clouds := config.GetClouds()
+	cloud, ok := clouds[cloudName]
+	if ! ok {
+		w.WriteHeader(http.StatusNotFound)
+		enc.Encode(v1.Error{
+			Code: http.StatusNotFound,
+			Message: "Cloud Not Found.",
+		})
+		return
+	}
+	cloud.Taint(t)
+	db.SaveTaints(cloud)
+	clouds[cloudName] = cloud
+	watcher.RequestTaintSync()
+	if err := enc.Encode(cloud); err != nil {
+		log.Err.Println(functionName, err)
+		w.WriteHeader(http.StatusInternalServerError)
+		enc.Encode(v1.Error{
+			Code: http.StatusInternalServerError,
+			Message: "Marshal JSON error",
+		})
+		return
+	}
+
+}
+
+func v1DeleteTaintByIndex(w http.ResponseWriter, req *http.Request, params httprouter.Params) {
+	functionName := "v1DeleteTaint:"
+	w.Header().Set("Content-Type", "application/json")
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", " ")
+	cloudName := params.ByName("cloudname")
+	if cloudName == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		enc.Encode(v1.Error{
+			Code: http.StatusBadRequest,
+			Message: "Cloud name must be specified in the request",
+		})
+		return
+	}
+
+	clouds := config.GetClouds()
+	cloud, ok := clouds[cloudName]
+	if ! ok {
+		w.WriteHeader(http.StatusNotFound)
+		enc.Encode(v1.Error{
+			Code: http.StatusNotFound,
+			Message: "Cloud Not Found.",
+		})
+		return
+	}
+
+	taintIndex, err := strconv.Atoi(params.ByName("taintindex"))
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		enc.Encode(v1.Error{
+			Code: http.StatusInternalServerError,
+			Message: "Can't convert index to integer",
+		})
+		return
+	}
+
+	if len(cloud.Taints) == 0 {
+		w.WriteHeader(http.StatusBadRequest)
+		enc.Encode(v1.Error{
+			Code: http.StatusBadRequest,
+			Message: fmt.Sprintf("Cloud %s has no taint.", cloud.Name),
+		})
+		return
+	}
+
+
+	if taintIndex >= len(cloud.Taints) || taintIndex < 0{
+		w.WriteHeader(http.StatusBadRequest)
+		enc.Encode(v1.Error{
+			Code: http.StatusBadRequest,
+			Message: fmt.Sprintf("Taint index out of range (must be 0..%d)", len(cloud.Taints)-1),
+		})
+		return
+	}
+
+	cloud.Taints = append(cloud.Taints[:taintIndex], cloud.Taints[taintIndex+1:]...)
+	clouds[cloudName] = cloud
+	db.SaveTaints(cloud)
+	watcher.RequestTaintSync()
+	if err := enc.Encode(cloud); err != nil {
+		log.Err.Println(functionName, err)
+		w.WriteHeader(http.StatusInternalServerError)
+		enc.Encode(v1.Error{
+			Code: http.StatusInternalServerError,
+			Message: "Marshal JSON error",
+		})
+		return
+	}
+}
+
+func v1DeleteTaintByCloudName(w http.ResponseWriter, req *http.Request, params httprouter.Params) {
+	functionName := "v1DeleteTaintByCloudName:"
+	w.Header().Set("Content-Type", "application/json")
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", " ")
+	cloudName := params.ByName("cloudname")
+	if cloudName == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		enc.Encode(v1.Error{
+			Code: http.StatusBadRequest,
+			Message: "Cloud name must be specified in the request",
+		})
+		return
+	}
+	clouds := config.GetClouds()
+	cloud, ok := clouds[cloudName]
+	if ! ok {
+		w.WriteHeader(http.StatusNotFound)
+		enc.Encode(v1.Error{
+			Code: http.StatusNotFound,
+			Message: "Cloud Not Found.",
+		})
+		return
+	}
+
+	body, err := ioutil.ReadAll(req.Body)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		log.Err.Println("POST schedule", err)
+		enc.Encode(v1.Error{
+			Code: http.StatusBadRequest,
+			Message: "Error reading body from request.",
+		})
+		return
+	}
+	log.Out.Println(functionName, "Body received: ", string(body))
+
+	if ! json.Valid([]byte(body)) {
+		w.WriteHeader(http.StatusBadRequest)
+		enc.Encode(v1.Error{
+			Code: http.StatusBadRequest,
+			Message: "Body is not valid JSON.",
+		})
+		return
+	}
+
+	dec := json.NewDecoder(strings.NewReader(string(body)))
+	dec.DisallowUnknownFields()
+	t := v1.NewTaint()
+	if err := dec.Decode(&t); err != io.EOF  && err != nil {
+		log.Out.Println(functionName, err)
+		w.WriteHeader(http.StatusBadRequest)
+		enc.Encode(v1.Error{
+			Code: http.StatusBadRequest,
+			Message: "Error reading data from body. "+err.Error(),
+		})
+		return
+	}
+
+	if t.Key == "" || t.Effect == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		enc.Encode(v1.Error{
+			Code: http.StatusBadRequest,
+			Message: "Taint must have 'key' and 'effect'. ",
+		})
+		return
+	}
+
+	if t.Effect != v1.TaintEffectNoSchedule && t.Effect != v1.TaintEffectPreferNoSchedule {
+		w.WriteHeader(http.StatusBadRequest)
+		enc.Encode(v1.Error{
+			Code: http.StatusBadRequest,
+			Message: "Taint.effect must be 'NoSchedule' or 'PreferNoSchedule'. ",
+		})
+		return
+	}
+
+	if len(cloud.Taints) == 0 {
+		w.WriteHeader(http.StatusBadRequest)
+		enc.Encode(v1.Error{
+			Code: http.StatusBadRequest,
+			Message: fmt.Sprintf("Cloud %s has no taint.", cloud.Name),
+		})
+		return
+	}
+
+	// Remove the taint, build new taint list
+	result := []v1.Taint{}
+	for _, taint := range cloud.Taints {
+		if ! taint.MatchTaint(t) {
+			result = append(result, taint)
+		}
+	}
+	cloud.Taints = result
+	clouds[cloudName] = cloud
+	db.SaveTaints(cloud)
+	watcher.RequestTaintSync()
+	if err := enc.Encode(cloud); err != nil {
+		log.Err.Println(functionName, err)
+		w.WriteHeader(http.StatusInternalServerError)
+		enc.Encode(v1.Error{
+			Code: http.StatusInternalServerError,
+			Message: "Marshal JSON error",
+		})
+		return
+	}
+}
+
+func v1DeleteTaintsByCloudName(w http.ResponseWriter, req *http.Request, params httprouter.Params) {
+	functionName := "v1DeleteTaintByCloudName:"
+	w.Header().Set("Content-Type", "application/json")
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", " ")
+	cloudName := params.ByName("cloudname")
+	if cloudName == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		enc.Encode(v1.Error{
+			Code: http.StatusBadRequest,
+			Message: "Cloud name must be specified in the request",
+		})
+		return
+	}
+
+	clouds := config.GetClouds()
+	cloud, ok := clouds[cloudName]
+	if ! ok {
+		w.WriteHeader(http.StatusNotFound)
+		enc.Encode(v1.Error{
+			Code: http.StatusNotFound,
+			Message: "Cloud Not Found.",
+		})
+		return
+	}
+
+	if len(cloud.Taints) == 0 {
+		w.WriteHeader(http.StatusBadRequest)
+		enc.Encode(v1.Error{
+			Code: http.StatusBadRequest,
+			Message: fmt.Sprintf("Cloud %s has no taint.", cloud.Name),
+		})
+		return
+	}
+
+	cloud.Taints = []v1.Taint{}
+	clouds[cloudName] = cloud
+	db.SaveTaints(cloud)
+	watcher.RequestTaintSync()
+	if err := enc.Encode(cloud); err != nil {
+		log.Err.Println(functionName, err)
+		w.WriteHeader(http.StatusInternalServerError)
+		enc.Encode(v1.Error{
+			Code: http.StatusInternalServerError,
+			Message: "Marshal JSON error",
+		})
+		return
+	}
+}

--- a/internal/api/v1/cloud.go
+++ b/internal/api/v1/cloud.go
@@ -4,3 +4,24 @@ package v1
 func NewCloud() Cloud {
 	return Cloud{Enabled: true}
 }
+
+func (c Cloud) IsTolerated(tolerations []Toleration, effect string) bool {
+taintLoop:
+	for _, taint := range c.Taints {
+		// Ignore Taint if effect is not the one passed
+		if taint.Effect != effect {
+			continue taintLoop
+		}
+	tolerationLoop:
+		for _, tol := range tolerations {
+			if tol.ToleratesTaint(taint) {
+				continue taintLoop
+			} else {
+				continue tolerationLoop
+			}
+		}
+
+		return false
+	}
+	return true
+}

--- a/internal/api/v1/taint.go
+++ b/internal/api/v1/taint.go
@@ -1,0 +1,54 @@
+package v1
+
+import (
+	"fmt"
+	"time"
+)
+
+
+// MatchTaint checks if the taint matches taintToMatch. Taints are unique by key:effect,
+// if the two taints have same key:effect, regard as they match.
+func (t Taint) MatchTaint(taintToMatch Taint) bool {
+	return t.Key == taintToMatch.Key && t.Effect == taintToMatch.Effect
+}
+
+// ToString converts taint struct to string in format '<key>=<value>:<effect>', '<key>=<value>:', '<key>:<effect>', or '<key>'.
+func (t Taint) String() string {
+	if len(t.Effect) == 0 {
+		if len(t.Value) == 0 {
+			return fmt.Sprintf("%v", t.Key)
+		}
+		return fmt.Sprintf("%v=%v:", t.Key, t.Value)
+	}
+	if len(t.Value) == 0 {
+		return fmt.Sprintf("%v:%v", t.Key, t.Effect)
+	}
+	return fmt.Sprintf("%v=%v:%v", t.Key, t.Value, t.Effect)
+}
+
+// Taint method taints a cloud with the provided Taint
+func (c *Cloud) Taint (t Taint) {
+	for i, v := range c.Taints {
+		if t.MatchTaint(v) {
+			// already tainted with that taint
+			c.Taints[i] = t
+			return
+		}
+	}
+	c.Taints = append(c.Taints, t)
+}
+
+func NewTaint() Taint {
+	return Taint{
+		CreationTimestamp: time.Now().UTC().Round(time.Second),
+	}
+}
+
+func (taint Taint) IsTolerated(tolerations []Toleration) bool {
+	for _, tol := range tolerations {
+		if tol.ToleratesTaint(taint) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/api/v1/taint_test.go
+++ b/internal/api/v1/taint_test.go
@@ -1,0 +1,119 @@
+package v1
+
+import (
+	"testing"
+)
+
+func TestTaintToString(t *testing.T) {
+	testCases := []struct {
+		taint          *Taint
+		expectedString string
+	}{
+		{
+			taint: &Taint{
+				Key:    "foo",
+				Value:  "bar",
+				Effect: TaintEffectNoSchedule,
+			},
+			expectedString: "foo=bar:NoSchedule",
+		},
+		{
+			taint: &Taint{
+				Key:    "foo",
+				Effect: TaintEffectNoSchedule,
+			},
+			expectedString: "foo:NoSchedule",
+		},
+		{
+			taint: &Taint{
+				Key: "foo",
+			},
+			expectedString: "foo",
+		},
+		{
+			taint: &Taint{
+				Key:   "foo",
+				Value: "bar",
+			},
+			expectedString: "foo=bar:",
+		},
+	}
+
+	for i, tc := range testCases {
+		if tc.expectedString != tc.taint.String() {
+			t.Errorf("[%v] expected taint %v converted to %s, got %s", i, tc.taint, tc.expectedString, tc.taint.String())
+		}
+	}
+}
+
+func TestMatchTaint(t *testing.T) {
+	testCases := []struct {
+		description  string
+		taint        *Taint
+		taintToMatch Taint
+		expectMatch  bool
+	}{
+		{
+			description: "two taints with the same key,value,effect should match",
+			taint: &Taint{
+				Key:    "foo",
+				Value:  "bar",
+				Effect: TaintEffectNoSchedule,
+			},
+			taintToMatch: Taint{
+				Key:    "foo",
+				Value:  "bar",
+				Effect: TaintEffectNoSchedule,
+			},
+			expectMatch: true,
+		},
+		{
+			description: "two taints with the same key,effect but different value should match",
+			taint: &Taint{
+				Key:    "foo",
+				Value:  "bar",
+				Effect: TaintEffectNoSchedule,
+			},
+			taintToMatch: Taint{
+				Key:    "foo",
+				Value:  "different-value",
+				Effect: TaintEffectNoSchedule,
+			},
+			expectMatch: true,
+		},
+		{
+			description: "two taints with the different key cannot match",
+			taint: &Taint{
+				Key:    "foo",
+				Value:  "bar",
+				Effect: TaintEffectNoSchedule,
+			},
+			taintToMatch: Taint{
+				Key:    "different-key",
+				Value:  "bar",
+				Effect: TaintEffectNoSchedule,
+			},
+			expectMatch: false,
+		},
+		{
+			description: "two taints with the different effect cannot match",
+			taint: &Taint{
+				Key:    "foo",
+				Value:  "bar",
+				Effect: TaintEffectNoSchedule,
+			},
+			taintToMatch: Taint{
+				Key:    "foo",
+				Value:  "bar",
+				Effect: TaintEffectPreferNoSchedule,
+			},
+			expectMatch: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		if tc.expectMatch != tc.taint.MatchTaint(tc.taintToMatch) {
+			t.Errorf("[%s] expect taint %s match taint %s", tc.description, tc.taint.String(), tc.taintToMatch.String())
+		}
+	}
+}

--- a/internal/api/v1/types.go
+++ b/internal/api/v1/types.go
@@ -21,7 +21,7 @@ type Cloud struct {
 	// deployment to be scheduled unless that deployment has a matching toleration.
 	// Taints are usually dynamic resources managed by the scheduler, but they can also
 	// be statically provided in the configuration.
-	Taints map[string]Taint `json:"taints"`
+	Taints []Taint `json:"taints,omitempty"`
 }
 
 type Error struct {
@@ -49,33 +49,38 @@ type GitCommit struct {
 }
 
 const(
-	// Do not allow new deployments to be scheduled onto the cloud
-	// unless they tolerate the taint
+	// TaintEffectNoSchedule does not allow new deployments to be scheduled
+	// onto the cloud unless they tolerate the taint
 	TaintEffectNoSchedule string = "NoSchedule"
-	// Like TaintEffectNoSchedule, but the scheduler tries not to schedule
-	// new deployments onto the cloud, rather than prohibiting new deployment
-	// from scheduling onto the cloud entirely.
+	// TaintEffectPreferNoSchedule is like TaintEffectNoSchedule,
+	// but the scheduler tries not to schedule new deployments onto the cloud,
+	// rather than prohibiting new deployment from scheduling onto the cloud entirely.
 	TaintEffectPreferNoSchedule string = "PreferNoSchedule"
 
 	TolerationOpExists string = "Exists"
 	TolerationOpEqual  string = "Equal"
 )
 
-
-// The cloud this taint is attached to has the "effect" on any deployment that
+// Taint : The cloud this taint is attached to has the "effect" on any deployment that
 // does not tolerate the Taint.
 type Taint struct {
 	// Required. The taint key to be applied to a cloud.
 	Key string `json:"key"`
 	// The taint value corresponding to the taint key.
 	// +optional
-	Value string `json:"value"`
+	Value string `json:"value,omitempty"`
 	// Required. The effect of the taint on deployments that do not tolerate the taint.
 	// Valid effects are NoSchedule, PreferNoSchedule.
 	Effect string `json:"effect"`
+	// CreationTimestamp the Taint was added.
+	// +optional
+	CreationTimestamp time.Time `json:"creation_timestamp,omitempty"`
+	// ValidUntil is the time when the taint expires.
+	// +optional
+	ValidUntil time.Time `json:"valid_until,omitempty"`
 }
 
-// The deployment this Toleration is attached to tolerates any taint that matches
+// Toleration : The deployment this Toleration is attached to tolerates any taint that matches
 // the triple <key,value,effect> using the matching operator <operator>.
 type Toleration struct {
 	// Key is the taint key that the toleration applies to. Empty means match all taint keys.

--- a/internal/api/v1/types.go
+++ b/internal/api/v1/types.go
@@ -75,9 +75,6 @@ type Taint struct {
 	// CreationTimestamp the Taint was added.
 	// +optional
 	CreationTimestamp time.Time `json:"creation_timestamp,omitempty"`
-	// ValidUntil is the time when the taint expires.
-	// +optional
-	ValidUntil time.Time `json:"valid_until,omitempty"`
 }
 
 // Toleration : The deployment this Toleration is attached to tolerates any taint that matches

--- a/internal/console/console.go
+++ b/internal/console/console.go
@@ -92,7 +92,7 @@ func getConfig(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
 var templateDir string
 
 // Serve function is
-func Serve(t string) {
+func Serve(t string, addr string) {
 	templateDir = t
 	router := httprouter.New()
 
@@ -101,6 +101,6 @@ func Serve(t string) {
 	router.GET("/get_config", getConfig)
 	router.GET("/reload_config", getReloadConfig)
 
-	log.Out.Println("Console listen on port :8081")
-	log.Err.Fatal(http.ListenAndServe(":8081", router))
+	log.Out.Println("Console listen on port", addr)
+	log.Err.Fatal(http.ListenAndServe(addr, router))
 }

--- a/internal/db/cloud.go
+++ b/internal/db/cloud.go
@@ -1,0 +1,72 @@
+package db
+
+import(
+	"encoding/json"
+	"fmt"
+	"errors"
+	"github.com/redhat-gpe/agnostics/internal/log"
+	"github.com/redhat-gpe/agnostics/internal/api/v1"
+	"github.com/gomodule/redigo/redis"
+)
+
+func SaveTaints(cloud v1.Cloud) error {
+	conn, err := Dial()
+	if err != nil {
+		log.Err.Println("Cannot connect to redis:", err)
+		return err
+	}
+	defer conn.Close()
+
+	jsonText, err :=  json.Marshal(cloud.Taints)
+	if reply, err := conn.Do("JSON.SET", "taints:"+cloud.Name, ".", jsonText); err != nil {
+		log.Err.Println("cloud.SaveTaints(taints:", cloud.Name,")", err)
+		return err
+	} else {
+		log.Debug.Println("cloud.SaveTaints(taints:",cloud.Name, ")", reply)
+		return nil
+	}
+
+}
+
+func ReloadAllTaints(clouds map[string]v1.Cloud) error {
+	functionName := "ReloadAllTaints:"
+	for k, v := range clouds {
+		taints, err := getTaints(v)
+		if err != nil {
+			log.Err.Println(functionName, err)
+		}
+		v.Taints = taints
+		clouds[k] = v
+	}
+	log.Out.Println(functionName, "OK")
+	return nil
+}
+
+// Error when the placement is not found using Uuid
+var ErrTaintsNotFound = errors.New("taints not found")
+
+func getTaints(cloud v1.Cloud) ([]v1.Taint, error) {
+	conn, err := Dial()
+	if err != nil {
+		log.Err.Println("Cannot connect to redis:", err)
+		return []v1.Taint{}, err
+	}
+	defer conn.Close()
+
+	key := fmt.Sprintf("taints:%s", cloud.Name)
+
+	if reply, err := redis.Bytes(conn.Do("JSON.GET", key)); err != nil {
+		if err == redis.ErrNil {
+			return []v1.Taint{}, nil
+		}
+		return []v1.Taint{}, err
+	} else if reply == nil {
+		return []v1.Taint{}, nil
+	} else {
+		var taints []v1.Taint
+		if err := json.Unmarshal(reply, &taints); err != nil {
+			return []v1.Taint{}, err
+		}
+		return taints, nil
+	}
+}

--- a/internal/modules/labels.go
+++ b/internal/modules/labels.go
@@ -6,11 +6,11 @@ import (
 	"math/rand"
 )
 
-func LabelPredicates(clouds map[string]v1.Cloud, labels map[string]string) map[string]v1.Cloud {
-	result := map[string]v1.Cloud{}
+func LabelPredicates(clouds []v1.Cloud, labels map[string]string) []v1.Cloud {
+	result := []v1.Cloud{}
 
 out:
-	for k, v := range clouds {
+	for _, v := range clouds {
 		if v.Enabled == false {
 			continue out
 		}
@@ -21,7 +21,7 @@ out:
 			}
 		}
 		// All labels match, we can keep that cloud
-		result[k] = v
+		result = append(result, v)
 	}
 	return result
 }
@@ -35,13 +35,13 @@ func (a ByWeight) Len() int           { return len(a) }
 func (a ByWeight) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 func (a ByWeight) Less(i, j int) bool { return a[i].Weight >= a[j].Weight }
 
-func applyPriorityWeight(clouds map[string]v1.Cloud, preferences map[string]string) []v1.Cloud {
+func applyPriorityWeight(clouds []v1.Cloud, preferences map[string]string, weight int) []v1.Cloud {
 	result := []v1.Cloud{}
 	for _, v := range clouds {
 		for kp, vp := range preferences {
 			if vl, ok := v.Labels[kp]; ok {
 				if vl == vp {
-					v.Weight = v.Weight + 1
+					v.Weight = v.Weight + weight
 				}
 			}
 		}
@@ -51,8 +51,8 @@ func applyPriorityWeight(clouds map[string]v1.Cloud, preferences map[string]stri
 }
 
 
-func LabelPriorities(clouds map[string]v1.Cloud, preferences map[string]string) []v1.Cloud {
-	result := applyPriorityWeight(clouds, preferences)
+func LabelPriorities(clouds []v1.Cloud, preferences map[string]string, weight int) []v1.Cloud {
+	result := applyPriorityWeight(clouds, preferences, weight)
 	rand.Shuffle(len(result), func(i, j int) {
 		result[i], result[j] = result[j], result[i]
 	})

--- a/internal/modules/labels_test.go
+++ b/internal/modules/labels_test.go
@@ -8,11 +8,11 @@ import (
 func TestLabelPredicates(t *testing.T) {
 	var (
 		labels map[string]string
-		clouds map[string]v1.Cloud
-		result map[string]v1.Cloud
+		clouds []v1.Cloud
+		result []v1.Cloud
 	)
-	clouds = map[string]v1.Cloud{
-		"openstack-1": v1.Cloud{
+	clouds = []v1.Cloud{
+		{
 			Name: "openstack-1",
 			Enabled: true,
 			Labels: map[string]string{
@@ -21,7 +21,7 @@ func TestLabelPredicates(t *testing.T) {
 				"purpose": "development",
 			},
 		},
-		"openstack-2": v1.Cloud{
+		{
 			Name: "openstack-2",
 			Enabled: true,
 			Labels: map[string]string{
@@ -30,7 +30,7 @@ func TestLabelPredicates(t *testing.T) {
 				"purpose": "ILT",
 			},
 		},
-		"openstack-3": v1.Cloud{
+		{
 			Name: "openstack-3",
 			Enabled: true,
 			Labels: map[string]string{
@@ -39,7 +39,7 @@ func TestLabelPredicates(t *testing.T) {
 				"purpose": "ELT",
 			},
 		},
-		"openstack-disabled": v1.Cloud{
+		{
 			Name: "openstack-disabled",
 			Enabled: false,
 			Labels: map[string]string{
@@ -65,10 +65,10 @@ func TestLabelPredicates(t *testing.T) {
 	if len(result) != 2 {
 		t.Error(clouds, labels, result)
 	}
-	if _, ok := result["openstack-2"]; ! ok {
+	if result[0].Name != "openstack-2" {
 		t.Error(clouds, labels, result)
 	}
-	if _, ok := result["openstack-3"]; ! ok {
+	if result[1].Name != "openstack-3" {
 		t.Error(clouds, labels, result)
 	}
 
@@ -80,7 +80,7 @@ func TestLabelPredicates(t *testing.T) {
 	if len(result) != 1 {
 		t.Error(clouds, labels, result)
 	}
-	if _, ok := result["openstack-2"]; ! ok {
+	if result[0].Name != "openstack-2" {
 		t.Error(clouds, labels, result)
 	}
 
@@ -98,12 +98,12 @@ func TestLabelPredicates(t *testing.T) {
 func TestLabelPriorities(t *testing.T) {
 	var (
 		preferences map[string]string
-		clouds map[string]v1.Cloud
+		clouds []v1.Cloud
 		result []v1.Cloud
 	)
 
-	clouds = map[string]v1.Cloud{
-		"openstack-1": v1.Cloud{
+	clouds = []v1.Cloud{
+		{
 			Name: "openstack-1",
 			Labels: map[string]string{
 				"type": "osp",
@@ -111,7 +111,7 @@ func TestLabelPriorities(t *testing.T) {
 				"purpose": "development",
 			},
 		},
-		"openstack-2": v1.Cloud{
+		{
 			Name: "openstack-2",
 			Labels: map[string]string{
 				"type": "osp",
@@ -119,7 +119,7 @@ func TestLabelPriorities(t *testing.T) {
 				"purpose": "ILT",
 			},
 		},
-		"openstack-3": v1.Cloud{
+		{
 			Name: "openstack-3",
 			Labels: map[string]string{
 				"type": "osp",
@@ -127,7 +127,7 @@ func TestLabelPriorities(t *testing.T) {
 				"purpose": "ELT",
 			},
 		},
-		"openstack-4": v1.Cloud{
+		{
 			Name: "openstack-4",
 			Labels: map[string]string{
 				"type": "osp",
@@ -135,7 +135,7 @@ func TestLabelPriorities(t *testing.T) {
 				"purpose": "ELT",
 			},
 		},
-		"openstack-5": v1.Cloud{
+		{
 			Name: "openstack-5",
 			Labels: map[string]string{
 				"type": "osp",
@@ -143,7 +143,7 @@ func TestLabelPriorities(t *testing.T) {
 				"purpose": "development",
 			},
 		},
-		"openstack-6": v1.Cloud{
+		{
 			Name: "openstack-6",
 			Labels: map[string]string{
 				"type": "osp",
@@ -156,7 +156,7 @@ func TestLabelPriorities(t *testing.T) {
 		"region": "sa",
 	}
 
-	result = LabelPriorities(clouds, preferences)
+	result = LabelPriorities(clouds, preferences, 1)
 
 	if len(result) != len(clouds) {
 		t.Error(preferences, result)
@@ -170,7 +170,7 @@ func TestLabelPriorities(t *testing.T) {
 		"purpose": "development",
 	}
 
-	result = LabelPriorities(clouds, preferences)
+	result = LabelPriorities(clouds, preferences, 1)
 
 	if len(result) != len(clouds) {
 		t.Error(preferences, result)

--- a/internal/modules/taints_test.go
+++ b/internal/modules/taints_test.go
@@ -21,80 +21,80 @@ func sliceEqual(a, b []string) bool {
 }
 
 func TestTaintPredicates (t *testing.T) {
-	clouds := map[string]v1.Cloud{
-		"openstack-1": v1.Cloud{
+	clouds := []v1.Cloud{
+		{
 			Name: "openstack-1",
-			Taints: map[string]v1.Taint{},
+			Taints: []v1.Taint{},
 		},
-		"openstack-2": v1.Cloud{
+		{
 			Name: "openstack-2",
-			Taints: map[string]v1.Taint{
-				"memory-pressure": {
+			Taints: []v1.Taint{
+				{
 					Key: "memory-pressure",
 					Value: "high",
 					Effect: v1.TaintEffectPreferNoSchedule,
 				},
 			},
 		},
-		"openstack-3": v1.Cloud{
+		{
 			Name: "openstack-3",
-			Taints: map[string]v1.Taint{
-				"memory-pressure": {
+			Taints: []v1.Taint{
+				{
 					Key: "memory-pressure",
 					Value: "critical",
 					Effect: v1.TaintEffectNoSchedule,
 				},
 			},
 		},
-		"openstack-4": v1.Cloud{
+		{
 			Name: "openstack-4",
-			Taints: map[string]v1.Taint{
-				"custom-taint": {
+			Taints: []v1.Taint{
+				{
 					Key: "custom-taint",
 					Value: "custom-value",
 					Effect: v1.TaintEffectNoSchedule,
 				},
 			},
 		},
-		"openstack-5": v1.Cloud{
+		{
 			Name: "openstack-5",
-			Taints: map[string]v1.Taint{
-				"cpu-pressure": {
+			Taints: []v1.Taint{
+				{
 					Key: "cpu-pressure",
 					Value: "critical",
 					Effect: v1.TaintEffectNoSchedule,
 				},
 			},
 		},
-		"openstack-6": v1.Cloud{
+		{
 			Name: "openstack-6",
-			Taints: map[string]v1.Taint{
-				"disk-pressure": {
+			Taints: []v1.Taint{
+				{
 					Key: "disk-pressure",
 					Value: "high",
 					Effect: v1.TaintEffectNoSchedule,
 				},
 			},
 		},
-		"openstack-7": v1.Cloud{
+		{
 			Name: "openstack-7",
-			Taints: map[string]v1.Taint{
-				"disk-pressure": {
+			Taints: []v1.Taint{
+				{
 					Key: "disk-pressure",
 					Value: "critical",
 					Effect: v1.TaintEffectNoSchedule,
 				},
 			},
 		},
-		"openstack-8": v1.Cloud{
+		{
 			Name: "openstack-8",
-			Taints: map[string]v1.Taint{
-				"disk-pressure": {
+			Taints: []v1.Taint{
+				{
 					Key: "disk-pressure",
 					Value: "critical",
 					Effect: v1.TaintEffectNoSchedule,
 				},
-				"memory-pressure": {
+				{
 					Key: "memory-pressure",
 					Value: "critical",
 					Effect: v1.TaintEffectNoSchedule,
@@ -104,7 +104,7 @@ func TestTaintPredicates (t *testing.T) {
 	}
 	testCases := []struct {
 		description string
-		clouds map[string]v1.Cloud
+		clouds []v1.Cloud
 		tolerations []v1.Toleration
 		expected []string
 	}{

--- a/templates/clouds.tmpl
+++ b/templates/clouds.tmpl
@@ -14,11 +14,9 @@
     <td><b>{{ .Name }}</b></td>
     <td>{{ countPlacements .Name }}</td>
     <td>
-      <ul>
         {{ range  $key, $val := .Labels }}
-        <li><code>{{ $key }}:&nbsp;{{ $val }}</code></li>
+        <code>{{ $key }}:&nbsp;{{ $val }}</code></br>
         {{end}}
-      </ul>
     </td>
     <td>
       {{ if eq .Enabled true }}
@@ -27,7 +25,17 @@
       <span style="font-weight: bold; color: red">false</span>
       {{ end }}
     </td>
-    <td><pre>{{ marshal .Taints }}</pre></td>
+    <td>
+        {{ range .Taints }}
+        {{ if eq .Effect "NoSchedule"  }}
+        <span class="taint-noschedule">
+        {{ else }}
+        <span class="taint-prefernoschedule">
+        {{ end }}
+          <code>{{ . }}</code></span></br>
+        {{ end }}
+
+    </td>
   </tr>
   {{ end }}
 </table>

--- a/templates/config.tmpl
+++ b/templates/config.tmpl
@@ -16,5 +16,5 @@ $(document).ready(function(){
 });
 </script>
 
-<button id="reloadconfigbutton" type="submit" value="Submit">Force Reload</button>
+<button class="pure-button pure-button-primary" id="reloadconfigbutton" type="submit" value="Submit">Force Reload</button>
 <span id="reloadresult" style="color: gray"></span>

--- a/templates/layout.tmpl
+++ b/templates/layout.tmpl
@@ -19,6 +19,15 @@
     tr:nth-child(even) {
         background-color: #eeeeee;
     }
+    .taint-noschedule {
+        font-family: monospace;
+        color: red;
+        font-weight: bold;
+    }
+    .taint-prefernoschedule {
+        font-family: monospace;
+        color: orange;
+    }
   </style>
 </head>
 <body>

--- a/templates/placements.tmpl
+++ b/templates/placements.tmpl
@@ -19,11 +19,9 @@
             </span>
         </td>
         <td>
-            <ul>
-                {{ range $key, $val := .Annotations }}
-                <li><code>{{ $key }}:&nbsp;{{ $val }}</code></li>
-                {{ end }}
-            </ul>
+            {{ range $key, $val := .Annotations }}
+            <code>{{ $key }}:&nbsp;{{ $val }}</code></br>
+            {{ end }}
         </td>
         <td>{{ .Cloud.Name }}</td>
     </tr>


### PR DESCRIPTION
This is a big change, not intentionally intended

It originally started by adding the Taint & Toleration feature to AgnosticS.

- Update README: mention Config Git repository, add example
- Fix ansible example to use the scheduler
- Add API_ADDR and CONSOLE_ADDR environment variables to configure the
  listening address of both servers.
- Add a watcher to synchronize taints on the different frontends, using Redis.
- Bump API version to 1.0.2
- Add API endpoints to manipulate Taints (POST/DELETE)
- Add 3 different ways to delete Taints:
  - by using the body with a POST method
  - by using the index of the taint in the cloud (`DELETE /taint/{cloudName}/{taintIndex}`)
  - by deleting all taints from a cloud (`DELETE /taints/{cloudName}`)
- Improve swagger: add examples
- Add Toleration object definition to swagger
- Rename local variables to meaningful names instead of short names like 't'
- Add *policy* to configuration (git repo). The scheduler looks for
  `policy.yaml` file that describes the behavior of the scheduler. It
  is similar to the OpenShift scheduler policy configmap.
- Update unit tests to work with the new structure (`[]Taint` instead of `map[string]Taint`)
- New object in Redis: taints. Index them by cloud name and save them as
  JSON. Notify other frontends on the taintMQ channel when a change happens.
- All predicates and priorities functions now take `[]cloud` and not a
  map. They should be identical so the order can be changed in the
  `policy.yaml` config indifferently.
- Update console CSS, small cosmetic changes