### PR TITLE
Add authentication for the API (htpasswd)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -15,6 +15,14 @@ Usage of ./scheduler:
         The address API listens to.
         Environment variable: *API_ADDR*
          (default ":8080")
+  -api-auth
+        Enable authentication for the API.
+        Environment variable: *API_AUTH*  ('true' or 'false')
+         (default true)
+  -api-htpasswd string
+        The path of the htpasswd file to use for authentication for the API.
+        Environment variable: *API_HTPASSWD*
+         (default "api-htpasswd")
   -console-addr string
         The address the Console listens to.
         Environment variable: *CONSOLE_ADDR*

--- a/deployments/helm/templates/deployment.yaml
+++ b/deployments/helm/templates/deployment.yaml
@@ -34,6 +34,8 @@ spec:
               value: {{ .Values.git.redis_url }}
             - name: DEBUG
               value: {{ .Values.git.debug }}
+            - name: API_HTPASSWD
+              value: /secrets/api-htpasswd
           ports:
             - name: http
               containerPort: 8080
@@ -51,6 +53,10 @@ spec:
           volumeMounts:
             - name: agnostics-babylon-secret
               mountPath: /.ssh
+              readOnly: true
+            - name: agnostics-api-htpasswd
+              mountPath: /secrets
+              readOnly: true
 
       {{- with .Values.nodeSelector }}
       nodeSelector:
@@ -68,3 +74,6 @@ spec:
         - name: agnostics-babylon-secret
           secret:
             secretName: agnostics-babylon
+        - name: agnostics-api-htpasswd
+          secret:
+            secretName: {{ toYaml .Values.service.htpasswd_secret }}

--- a/deployments/helm/values.yaml
+++ b/deployments/helm/values.yaml
@@ -39,6 +39,7 @@ redis:
 service:
   type: ClusterIP
   port: 80
+  htpasswd_secret: agnostics-api-htpasswd
 
 console:
   type: ClusterIP

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/go-git/go-git/v5 v5.1.0
 	github.com/gomodule/redigo v1.8.2
 	github.com/julienschmidt/httprouter v1.3.0
+	github.com/tg123/go-htpasswd v1.0.0
 	golang.org/x/crypto v0.0.0-20200604202706-70a84ac30bf9 // indirect
 	golang.org/x/net v0.0.0-20200602114024-627f9648deb9 // indirect
 	golang.org/x/sys v0.0.0-20200610111108-226ff32320da // indirect

--- a/go.sum
+++ b/go.sum
@@ -54,9 +54,12 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/tg123/go-htpasswd v1.0.0 h1:Ze/pZsz73JiCwXIyJBPvNs75asKBgfodCf8iTEkgkXs=
+github.com/tg123/go-htpasswd v1.0.0/go.mod h1:eQTgl67UrNKQvEPKrDLGBssjVwYQClFZjALVLhIv8C0=
 github.com/xanzy/ssh-agent v0.2.1 h1:TCbipTQL2JiiCprBWx9frJ2eJlCYT00NmctrHxVAr70=
 github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0Bx9h2kr4=
 golang.org/x/crypto v0.0.0-20190219172222-a4c6cb3142f2/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+golang.org/x/crypto v0.0.0-20190228161510-8dd112bcdc25/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200604202706-70a84ac30bf9 h1:vEg9joUBmeBcK9iSJftGNf3coIG4HqZElCPehJsfAYM=

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -26,7 +26,7 @@ func healthHandler (w http.ResponseWriter, req *http.Request, _ httprouter.Param
 }
 
 func BasicAuth(h httprouter.Handle, myauth *htpasswd.File, authEnabled bool) httprouter.Handle {
-    return func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	return func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 
 		if ! authEnabled {
 			// Delegate request to the given handle
@@ -34,27 +34,27 @@ func BasicAuth(h httprouter.Handle, myauth *htpasswd.File, authEnabled bool) htt
 			return
 		}
 
-        const basicAuthPrefix string = "Basic "
+		const basicAuthPrefix string = "Basic "
 
-        // Get the Basic Authentication credentials
-        auth := r.Header.Get("Authorization")
-        if strings.HasPrefix(auth, basicAuthPrefix) {
-            // Check credentials
-            payload, err := base64.StdEncoding.DecodeString(auth[len(basicAuthPrefix):])
-            if err == nil {
-                pair := bytes.SplitN(payload, []byte(":"), 2)
-                if len(pair) == 2 && myauth.Match(string(pair[0]), string(pair[1])) {
-                    // Delegate request to the given handle
-                    h(w, r, ps)
-                    return
-                }
-            }
-        }
+		// Get the Basic Authentication credentials
+		auth := r.Header.Get("Authorization")
+		if strings.HasPrefix(auth, basicAuthPrefix) {
+			// Check credentials
+			payload, err := base64.StdEncoding.DecodeString(auth[len(basicAuthPrefix):])
+			if err == nil {
+				pair := bytes.SplitN(payload, []byte(":"), 2)
+				if len(pair) == 2 && myauth.Match(string(pair[0]), string(pair[1])) {
+					// Delegate request to the given handle
+					h(w, r, ps)
+					return
+				}
+			}
+		}
 
-        // Request Basic Authentication otherwise
-        w.Header().Set("WWW-Authenticate", "Basic realm=Restricted")
-        http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
-    }
+		// Request Basic Authentication otherwise
+		w.Header().Set("WWW-Authenticate", "Basic realm=Restricted")
+		http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+	}
 }
 
 func Serve(addr string, apiAuth bool, apiHtpasswd string) {

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -6,6 +6,11 @@ import (
 	"github.com/redhat-gpe/agnostics/internal/db"
 	"github.com/redhat-gpe/agnostics/internal/log"
 	"io"
+	"strings"
+	"encoding/base64"
+	"bytes"
+	"github.com/tg123/go-htpasswd"
+	"path/filepath"
 )
 
 func healthHandler (w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
@@ -20,7 +25,39 @@ func healthHandler (w http.ResponseWriter, req *http.Request, _ httprouter.Param
 	io.WriteString(w, "OK\n")
 }
 
-func Serve(addr string) {
+func BasicAuth(h httprouter.Handle, myauth *htpasswd.File, authEnabled bool) httprouter.Handle {
+    return func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+
+		if ! authEnabled {
+			// Delegate request to the given handle
+			h(w, r, ps)
+			return
+		}
+
+        const basicAuthPrefix string = "Basic "
+
+        // Get the Basic Authentication credentials
+        auth := r.Header.Get("Authorization")
+        if strings.HasPrefix(auth, basicAuthPrefix) {
+            // Check credentials
+            payload, err := base64.StdEncoding.DecodeString(auth[len(basicAuthPrefix):])
+            if err == nil {
+                pair := bytes.SplitN(payload, []byte(":"), 2)
+                if len(pair) == 2 && myauth.Match(string(pair[0]), string(pair[1])) {
+                    // Delegate request to the given handle
+                    h(w, r, ps)
+                    return
+                }
+            }
+        }
+
+        // Request Basic Authentication otherwise
+        w.Header().Set("WWW-Authenticate", "Basic realm=Restricted")
+        http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+    }
+}
+
+func Serve(addr string, apiAuth bool, apiHtpasswd string) {
 	router := httprouter.New()
 
 	// Health and status checks
@@ -29,20 +66,40 @@ func Serve(addr string) {
 	router.GET("/api/v1/health", healthHandler)
 	router.GET("/api/v1/healthz", healthHandler)
 
+	// htpasswd authentication
+	if ! apiAuth {
+		apiHtpasswd = "/dev/null"
+		log.Out.Println("API authentication disabled")
+	}
+	absAPIHtpasswdPath, err := filepath.Abs(apiHtpasswd)
+	if err != nil {
+		log.Err.Println("ERROR with api-htpasswd-path")
+		log.Err.Fatal(err)
+	}
+	myauth, err := htpasswd.New(absAPIHtpasswdPath, htpasswd.DefaultSystems, nil)
+	if err != nil {
+		log.Err.Println("ERROR loading htpasswd", absAPIHtpasswdPath)
+		log.Err.Fatal(err)
+	} else {
+		if apiAuth {
+			log.Out.Println("htpasswd found:", absAPIHtpasswdPath)
+		}
+	}
+
 	// v1
-	router.GET("/api/v1/clouds", v1GetClouds)
-	router.GET("/api/v1/clouds/:name", v1GetCloudByName)
-	router.POST("/api/v1/taint/:cloudname", v1PostTaintByCloudName)
-	router.POST("/api/v1/taint/:cloudname/delete", v1DeleteTaintByCloudName)
-	router.DELETE("/api/v1/taint/:cloudname/:taintindex", v1DeleteTaintByIndex)
-	router.DELETE("/api/v1/taints/:cloudname", v1DeleteTaintsByCloudName)
-	router.GET("/api/v1/repo", v1GetRepository)
-	router.PUT("/api/v1/repo", v1PullRepository)
-	router.POST("/api/v1/schedule", v1PostSchedule)
-	router.GET("/api/v1/placements", v1GetPlacements)
-	router.GET("/api/v1/placements/:uuid", v1GetPlacement)
-	router.DELETE("/api/v1/placements/:uuid", v1DeletePlacement)
-	router.PUT("/api/v1/counters", v1PutCounters)
+	router.GET("/api/v1/clouds", BasicAuth(v1GetClouds, myauth, apiAuth))
+	router.GET("/api/v1/clouds/:name", BasicAuth(v1GetCloudByName, myauth, apiAuth))
+	router.POST("/api/v1/taint/:cloudname", BasicAuth(v1PostTaintByCloudName, myauth, apiAuth))
+	router.POST("/api/v1/taint/:cloudname/delete", BasicAuth(v1DeleteTaintByCloudName, myauth, apiAuth))
+	router.DELETE("/api/v1/taint/:cloudname/:taintindex", BasicAuth(v1DeleteTaintByIndex, myauth, apiAuth))
+	router.DELETE("/api/v1/taints/:cloudname", BasicAuth(v1DeleteTaintsByCloudName, myauth, apiAuth))
+	router.GET("/api/v1/repo", BasicAuth(v1GetRepository, myauth, apiAuth))
+	router.PUT("/api/v1/repo", BasicAuth(v1PullRepository, myauth, apiAuth))
+	router.POST("/api/v1/schedule", BasicAuth(v1PostSchedule, myauth, apiAuth))
+	router.GET("/api/v1/placements", BasicAuth(v1GetPlacements, myauth, apiAuth))
+	router.GET("/api/v1/placements/:uuid", BasicAuth(v1GetPlacement, myauth, apiAuth))
+	router.DELETE("/api/v1/placements/:uuid", BasicAuth(v1DeletePlacement, myauth, apiAuth))
+	router.PUT("/api/v1/counters", BasicAuth(v1PutCounters, myauth, apiAuth))
 
 	log.Out.Println("API listen on port", addr)
 	log.Err.Fatal(http.ListenAndServe(addr, router))


### PR DESCRIPTION
This commit, if applied, adds Basic HTTP authentication for the API
using htpasswd.

New dependency: github.com/tg123/go-htpasswd

The authentication is enabled by default but can be disabled.

All routes are behind authentication, except /health.