### PR TITLE
Fix to not set app.kubernetes.io/instance when release name not set

### DIFF
--- a/deployments/helm/templates/_helpers.tpl
+++ b/deployments/helm/templates/_helpers.tpl
@@ -30,5 +30,7 @@ Selector labels
 */}}
 {{- define "scheduler.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "scheduler.name" . }}
+  {{- if (ne .Release.Name "RELEASE-NAME") }}
 app.kubernetes.io/instance: {{ .Release.Name }}
-{{- end }}
+  {{- end -}}
+{{- end -}}


### PR DESCRIPTION
Because we are not setting release name with our template deploymet, the annotation `app.kubernetes.io/instance` is getting the default value `RELEASE-NAME`. This PR avoids setting this label when no release name is set.